### PR TITLE
Support TransactionOptions.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -674,11 +674,19 @@ Datastore.prototype.isKey = Datastore.isKey = function(value) {
 /**
  * Create a new Transaction object.
  *
+ * @param {object} [options] Configuration object.
+ * @param {string} [options.id] The ID of a previously run transaction.
+ * @param {boolean} [options.readOnly=false] A read-only transaction cannot
+ *     modify entities.
  * @returns {Transaction}
- * @private
+ *
+ * @example
+ * const Datastore = require('@google-cloud/datastore');
+ * const datastore = new Datastore();
+ * const transaction = datastore.transaction();
  */
-Datastore.prototype.transaction = function() {
-  return new Transaction(this);
+Datastore.prototype.transaction = function(options) {
+  return new Transaction(this, options);
 };
 
 /**

--- a/system-test/datastore.js
+++ b/system-test/datastore.js
@@ -979,5 +979,35 @@ describe('Datastore', function() {
         });
       });
     });
+
+    it('should read in a readOnly transaction', function(done) {
+      var transaction = datastore.transaction({ readOnly: true });
+      var key = datastore.key(['Company', 'Google']);
+
+      transaction.run(function(err) {
+        assert.ifError(err);
+        transaction.get(key, done);
+      });
+    });
+
+    it('should not write in a readOnly transaction', function(done) {
+      var transaction = datastore.transaction({ readOnly: true });
+      var key = datastore.key(['Company', 'Google']);
+
+      transaction.run(function(err) {
+        assert.ifError(err);
+
+        transaction.get(key, function(err) {
+          assert.ifError(err);
+
+          transaction.save({ key: key, data: {} });
+
+          transaction.commit(function(err) {
+            assert(err instanceof Error);
+            done();
+          });
+        });
+      });
+    });
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -397,6 +397,12 @@ describe('Datastore', function() {
       var transaction = datastore.transaction();
       assert.strictEqual(transaction.calledWith_[0], datastore);
     });
+
+    it('should pass options to the Transaction constructor', function() {
+      var options = {};
+      var transaction = datastore.transaction(options);
+      assert.strictEqual(transaction.calledWith_[1], options);
+    });
   });
 
   describe('determineBaseUrl_', function() {


### PR DESCRIPTION
Carrying over https://github.com/GoogleCloudPlatform/google-cloud-node/pull/2708

Change Overview and Requirements: https://github.com/GoogleCloudPlatform/google-cloud-python/issues/4278

This PR:

- Updates the Datastore proto files
- Allows setting the `BeginTransaction` rpc's `TransactionOptions`.

Examples:

#### Global-Level Setting
```js
var transaction = datastore.transaction({ readOnly: true });
transaction.run(function(err) {
  transaction.get(key, function() { /*...*/ });
});
```
```js
var transaction = datastore.transaction({ id: 'previous-id' });
transaction.run(function(err) {
  transaction.save({ key, data });
  transaction.commit(function(err) {});
});
```

#### Method-Level Setting
```js
var transaction = datastore.transaction();
transaction.run({ readOnly: true }, function(err) {
  transaction.get(key, function() { /*...*/ });
});
```
```js
var transaction = datastore.transaction();
transaction.run({ transactionId: 'previous-id' }, function(err) {
  transaction.save({ key, data });
  transaction.commit(function(err) {});
});
```

#### Raw Configuration (method level only)
```js
var options = {
  transactionOptions: {
    readWrite: {
      previousTransaction: 'previous-id'
    }
  }
};

var transaction = datastore.run(options, function(err) {
  transaction.save({ key, data });
  transaction.commit(function(err) {});
});
```