### PR TITLE
Return endCursor as a base64 string.

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -686,7 +686,7 @@ DatastoreRequest.prototype.runQueryStream = function(query, options) {
     };
 
     if (resp.batch.endCursor) {
-      info.endCursor = resp.batch.endCursor;
+      info.endCursor = resp.batch.endCursor.toString('base64');
     }
 
     var entities = [];

--- a/test/request.js
+++ b/test/request.js
@@ -939,7 +939,10 @@ describe('Request', function() {
         };
 
         FakeQuery.prototype.start = function(endCursor) {
-          assert.strictEqual(endCursor, apiResponse.batch.endCursor);
+          assert.strictEqual(
+            endCursor,
+            apiResponse.batch.endCursor.toString('base64')
+          );
           startCalled = true;
           return this;
         };
@@ -991,7 +994,7 @@ describe('Request', function() {
             assert.deepEqual(entities, allResults);
 
             assert.deepEqual(info, {
-              endCursor: apiResponse.batch.endCursor,
+              endCursor: apiResponse.batch.endCursor.toString('base64'),
               moreResults: apiResponse.batch.moreResults,
             });
 


### PR DESCRIPTION
Fixes #20 

When we switched to GAPIC, we inadvertently began returning `info.endCursor` as a Buffer. In the previous version (<=1.1), we returned the Buffer base64-stringified.