### PR TITLE
v1.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/datastore",
   "description": "Cloud Datastore Client Library for Node.js",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {

--- a/samples/package.json
+++ b/samples/package.json
@@ -14,7 +14,7 @@
     "cover": "nyc --reporter=lcov --cache ava -T 20s --verbose test/*.test.js system-test/*.test.js && nyc report"
   },
   "dependencies": {
-    "@google-cloud/datastore": "1.3.0",
+    "@google-cloud/datastore": "1.3.1",
     "sinon": "4.1.2",
     "yargs": "10.0.3"
   },


### PR DESCRIPTION
## Fixes

- (#21): Starting from version 1.2.0, released Saturday, December 16th, 2017, we introduced an unintentional breaking change. Prior to 1.2.0, an `endCursor` property returned from a query was a base64-encoded string. However, we inadvertently began returning it as a Buffer. We have reversed this error starting from this release, `v0.3.1`. Sorry for the inconvenience, and thank you to @mcfarljw for reporting the error.