### PR TITLE
Numberify port from an emulator env var.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -713,7 +713,7 @@ Datastore.prototype.determineBaseUrl_ = function(customApiEndpoint) {
   }
 
   if (port.test(baseUrl)) {
-    this.port_ = baseUrl.match(port)[1];
+    this.port_ = Number(baseUrl.match(port)[1]);
   }
 
   this.baseUrl_ = baseUrl

--- a/test/index.js
+++ b/test/index.js
@@ -548,10 +548,10 @@ describe('Datastore', function() {
       assert.strictEqual(datastore.baseUrl_, 'localhost');
     });
 
-    it('should set port if one was found', function() {
+    it('should set Numberified port if one was found', function() {
       setHost('http://localhost:9090');
       datastore.determineBaseUrl_();
-      assert.strictEqual(datastore.port_, '9090');
+      assert.strictEqual(datastore.port_, 9090);
     });
 
     it('should not set customEndpoint_ when using default baseurl', function() {
@@ -573,7 +573,7 @@ describe('Datastore', function() {
     describe('with DATASTORE_EMULATOR_HOST environment variable', function() {
       var DATASTORE_EMULATOR_HOST = 'localhost:9090';
       var EXPECTED_BASE_URL = 'localhost';
-      var EXPECTED_PORT = '9090';
+      var EXPECTED_PORT = 9090;
 
       beforeEach(function() {
         setHost(DATASTORE_EMULATOR_HOST);


### PR DESCRIPTION
Fixes #23 

When a Datastore instance is created, we detect and pluck out the URL components of an emulator host via `determineBaseUrl_()`, then pass them to GAPIC, so that gRPC it can properly connect to the emulator. `determineBaseUrl_()` was making a mistake-- when it parsed out the `8081` port component, it cached it as a string instead of a number. Our constructor then tried to validate that a `port` existed by checking if it was a number. It was not, so we fell back to the default port, 443:

https://github.com/googleapis/nodejs-datastore/blob/53e9378f31038b945f996e147db725665f1d12ba/src/index.js

Now that we cache the port as a number, this check will pass, and we will pass along the correct port number to gRPC.