### PR TITLE
Provide user's project ID to google-auto-auth.

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "concat-stream": "^1.5.0",
     "create-error-class": "^3.0.2",
     "extend": "^3.0.1",
-    "google-auto-auth": "^0.8.2",
+    "google-auto-auth": "^0.9.0",
     "google-gax": "^0.14.2",
     "google-proto-files": "^0.13.1",
     "is": "^3.0.1",

--- a/src/index.js
+++ b/src/index.js
@@ -370,17 +370,22 @@ function Datastore(options) {
 
   this.clients_ = new Map();
   this.datastore = this;
+
   /**
    * @name Datastore#namespace
    * @type {string}
    */
   this.namespace = options.namespace;
+
+  const userProvidedProjectId =
+    process.env.DATASTORE_PROJECT_ID || options.projectId;
+  const defaultProjectId = '{{projectId}}';
+
   /**
    * @name Datastore#projectId
    * @type {string}
    */
-  this.projectId =
-    process.env.DATASTORE_PROJECT_ID || options.projectId || '{{projectId}}';
+  this.projectId = userProvidedProjectId || defaultProjectId;
 
   this.defaultBaseUrl_ = 'datastore.googleapis.com';
   this.determineBaseUrl_(options.apiEndpoint);
@@ -392,6 +397,7 @@ function Datastore(options) {
       scopes: gapic.v1.DatastoreClient.scopes,
       servicePath: this.baseUrl_,
       port: is.number(this.port_) ? this.port_ : 443,
+      projectId: userProvidedProjectId,
     },
     options
   );

--- a/src/index.js
+++ b/src/index.js
@@ -378,7 +378,7 @@ function Datastore(options) {
   this.namespace = options.namespace;
 
   const userProvidedProjectId =
-    process.env.DATASTORE_PROJECT_ID || options.projectId;
+    options.projectId || process.env.DATASTORE_PROJECT_ID;
   const defaultProjectId = '{{projectId}}';
 
   /**
@@ -401,7 +401,6 @@ function Datastore(options) {
     },
     options
   );
-
   if (this.customEndpoint_) {
     this.options.sslCreds = grpc.credentials.createInsecure();
   }

--- a/test/index.js
+++ b/test/index.js
@@ -90,6 +90,8 @@ describe('Datastore', function() {
   var PROJECT_ID = 'project-id';
   var NAMESPACE = 'namespace';
 
+  var DATASTORE_PROJECT_ID_CACHED = process.env.DATASTORE_PROJECT_ID;
+
   var OPTIONS = {
     projectId: PROJECT_ID,
     apiEndpoint: 'http://endpoint',
@@ -121,6 +123,14 @@ describe('Datastore', function() {
       projectId: PROJECT_ID,
       namespace: NAMESPACE,
     });
+  });
+
+  afterEach(function() {
+    if (typeof DATASTORE_PROJECT_ID_CACHED === 'string') {
+      process.env.DATASTORE_PROJECT_ID = DATASTORE_PROJECT_ID_CACHED;
+    } else {
+      delete process.env.DATASTORE_PROJECT_ID;
+    }
   });
 
   after(function() {
@@ -167,6 +177,7 @@ describe('Datastore', function() {
 
     it('should localize the projectId', function() {
       assert.strictEqual(datastore.projectId, PROJECT_ID);
+      assert.strictEqual(datastore.options.projectId, PROJECT_ID);
     });
 
     it('should default project ID to placeholder', function() {
@@ -174,21 +185,20 @@ describe('Datastore', function() {
       assert.strictEqual(datastore.projectId, '{{projectId}}');
     });
 
+    it('should not default options.projectId to placeholder', function() {
+      var datastore = new Datastore({});
+      assert.strictEqual(datastore.options.projectId, undefined);
+    });
+
     it('should use DATASTORE_PROJECT_ID', function() {
-      var datastoreProjectIdCached = process.env.DATASTORE_PROJECT_ID;
       var projectId = 'overridden-project-id';
 
       process.env.DATASTORE_PROJECT_ID = projectId;
 
-      var datastore = new Datastore(OPTIONS);
-
-      if (typeof datastoreProjectIdCached === 'string') {
-        process.env.DATASTORE_PROJECT_ID = datastoreProjectIdCached;
-      } else {
-        delete process.env.DATASTORE_PROJECT_ID;
-      }
+      var datastore = new Datastore({});
 
       assert.strictEqual(datastore.projectId, projectId);
+      assert.strictEqual(datastore.options.projectId, projectId);
     });
 
     it('should set the default base URL', function() {
@@ -209,6 +219,8 @@ describe('Datastore', function() {
     });
 
     it('should localize the options', function() {
+      delete process.env.DATASTORE_PROJECT_ID;
+
       var options = {
         a: 'b',
         c: 'd',
@@ -233,6 +245,8 @@ describe('Datastore', function() {
         )
       );
     });
+
+    it('should cache the correct projectId', function() {});
 
     it('should set port if detected', function() {
       var determineBaseUrl_ = Datastore.prototype.determineBaseUrl_;

--- a/test/index.js
+++ b/test/index.js
@@ -246,8 +246,6 @@ describe('Datastore', function() {
       );
     });
 
-    it('should cache the correct projectId', function() {});
-
     it('should set port if detected', function() {
       var determineBaseUrl_ = Datastore.prototype.determineBaseUrl_;
 

--- a/test/index.js
+++ b/test/index.js
@@ -181,7 +181,12 @@ describe('Datastore', function() {
       process.env.DATASTORE_PROJECT_ID = projectId;
 
       var datastore = new Datastore(OPTIONS);
-      process.env.DATASTORE_PROJECT_ID = datastoreProjectIdCached;
+
+      if (typeof datastoreProjectIdCached === 'string') {
+        process.env.DATASTORE_PROJECT_ID = datastoreProjectIdCached;
+      } else {
+        delete process.env.DATASTORE_PROJECT_ID;
+      }
 
       assert.strictEqual(datastore.projectId, projectId);
     });
@@ -222,6 +227,7 @@ describe('Datastore', function() {
             scopes: v1.DatastoreClient.scopes,
             servicePath: datastore.baseUrl_,
             port: 443,
+            projectId: undefined,
           },
           options
         )


### PR DESCRIPTION
Fixes #27 

When we switched to GAPIC, we put a funnel method in front of all API requests before they were sent to GAPIC. From that, we get the `projectId` from google-auto-auth, to fill in any placeholders. We overlooked a scenario where a projectId is provided by the user already, such as when they are using a local emulator.

After this PR, we will honor that project ID, and not ask google-auto-auth to try to grab it from a credentials file (which is not generally provided when users are working from a local emulator).