### PR TITLE
1.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/datastore",
   "description": "Cloud Datastore Client Library for Node.js",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {

--- a/samples/package.json
+++ b/samples/package.json
@@ -14,7 +14,7 @@
     "cover": "nyc --reporter=lcov --cache ava -T 20s --verbose test/*.test.js system-test/*.test.js && nyc report"
   },
   "dependencies": {
-    "@google-cloud/datastore": "1.3.2",
+    "@google-cloud/datastore": "1.3.3",
     "sinon": "4.1.2",
     "yargs": "10.0.3"
   },


### PR DESCRIPTION
## Fixes

- (#28): Authentication is no longer required when using the local Datastore emulator.