### PR TITLE
Don't modify Key constructor input path.

### DIFF
--- a/src/entity.js
+++ b/src/entity.js
@@ -158,9 +158,9 @@ entity.isDsGeoPoint = isDsGeoPoint;
  * Build a Datastore Key object.
  *
  * @class
- * @param {object} options - Configuration object.
- * @param {array} options.path - Key path.
- * @param {string} [options.namespace] - Optional namespace.
+ * @param {object} options Configuration object.
+ * @param {array} options.path Key path.
+ * @param {string} [options.namespace] Optional namespace.
  *
  * @example
  * const Datastore = require('@google-cloud/datastore');

--- a/src/entity.js
+++ b/src/entity.js
@@ -158,9 +158,9 @@ entity.isDsGeoPoint = isDsGeoPoint;
  * Build a Datastore Key object.
  *
  * @class
- * @param {object|string|array} Configuration object.
- * @param {string|array} options.path  Key path.
- * @param {string} [options.namespace] Optional namespace.
+ * @param {object} options - Configuration object.
+ * @param {array} options.path - Key path.
+ * @param {string} [options.namespace] - Optional namespace.
  *
  * @example
  * const Datastore = require('@google-cloud/datastore');
@@ -178,7 +178,7 @@ function Key(options) {
   this.namespace = options.namespace;
 
   if (options.path.length % 2 === 0) {
-    var identifier = options.path.pop();
+    var identifier = popPath();
 
     if (is.number(identifier) || isDsInt(identifier)) {
       this.id = identifier.value || identifier;
@@ -187,7 +187,7 @@ function Key(options) {
     }
   }
 
-  this.kind = options.path.pop();
+  this.kind = popPath();
 
   if (options.path.length > 0) {
     this.parent = new Key(options);
@@ -208,6 +208,13 @@ function Key(options) {
       ]);
     },
   });
+
+  // Allows recursive constructor calls without affecting input path.
+  function popPath() {
+    const path = options.path;
+    options.path = path.slice(0, -1);
+    return path[path.length - 1];
+  }
 }
 
 entity.Key = Key;

--- a/src/entity.js
+++ b/src/entity.js
@@ -177,8 +177,10 @@ function Key(options) {
    */
   this.namespace = options.namespace;
 
+  options.path = [].slice.call(options.path);
+
   if (options.path.length % 2 === 0) {
-    var identifier = popPath();
+    var identifier = options.path.pop();
 
     if (is.number(identifier) || isDsInt(identifier)) {
       this.id = identifier.value || identifier;
@@ -187,7 +189,7 @@ function Key(options) {
     }
   }
 
-  this.kind = popPath();
+  this.kind = options.path.pop();
 
   if (options.path.length > 0) {
     this.parent = new Key(options);
@@ -208,13 +210,6 @@ function Key(options) {
       ]);
     },
   });
-
-  // Allows recursive constructor calls without affecting input path.
-  function popPath() {
-    const path = options.path;
-    options.path = path.slice(0, -1);
-    return path[path.length - 1];
-  }
 }
 
 entity.Key = Key;

--- a/test/entity.js
+++ b/test/entity.js
@@ -155,6 +155,12 @@ describe('entity', function() {
       assert(key.parent instanceof entity.Key);
     });
 
+    it('should not modify input path', function() {
+      var inputPath = ['ParentKind', 1, 'Kind', 1];
+      new entity.Key({path: inputPath});
+      assert.deepEqual(inputPath, ['ParentKind', 1, 'Kind', 1]);
+    });
+
     it('should always compute the correct path', function() {
       var key = new entity.Key({path: ['ParentKind', 1, 'Kind', 1]});
       assert.deepEqual(key.path, ['ParentKind', 1, 'Kind', 1]);


### PR DESCRIPTION
Fixes #47. Also corrects some inconsistencies in Key constructor JSDocs. 

- [x] Tests and linter pass
- [x] Code coverage does not decrease
- [x] Appropriate docs were updated
