### PR TITLE
1.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/datastore",
   "description": "Cloud Datastore Client Library for Node.js",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {

--- a/samples/package.json
+++ b/samples/package.json
@@ -14,7 +14,7 @@
     "cover": "nyc --reporter=lcov --cache ava -T 20s --verbose test/*.test.js system-test/*.test.js && nyc report"
   },
   "dependencies": {
-    "@google-cloud/datastore": "1.3.3",
+    "@google-cloud/datastore": "1.3.4",
     "sinon": "4.1.2",
     "yargs": "10.0.3"
   },


### PR DESCRIPTION
Fixes #57 

# 1.3.4

## Fixes

- (#42): Honor user options when `new Datastore({options})` is used.
- (#48): Don't modify user input to `datastore.key()`. (Thanks, @beaulac!)