### PR TITLE
properly returns integer values for integer keys vs the string value

### DIFF
--- a/src/entity.js
+++ b/src/entity.js
@@ -657,7 +657,10 @@ function keyFromKeyProto(keyProto) {
 
     // only convert the id to an Integer Type object if it's not already a number
     if (path.idType === 'id') {
-      id = parseInt(id, 10) || new entity.Int(id);
+      var parsedInteger = parseInt(id, 10);
+      id = Number.isSafeInteger(parsedInteger)
+        ? parsedInteger
+        : new entity.Int(id);
     }
 
     if (is.defined(id)) {

--- a/src/entity.js
+++ b/src/entity.js
@@ -183,7 +183,7 @@ function Key(options) {
     var identifier = options.path.pop();
 
     if (is.number(identifier) || isDsInt(identifier)) {
-      this.id = parseInt(identifier.value, 10) || identifier;
+      this.id = identifier.value || identifier;
     } else if (is.string(identifier)) {
       this.name = identifier;
     }
@@ -655,8 +655,14 @@ function keyFromKeyProto(keyProto) {
 
     var id = path[path.idType];
 
+    // only convert the id to an Integer Type object if it's not already a number
     if (path.idType === 'id') {
-      id = new entity.Int(id);
+      var parsedInt = parseInt(id, 10);
+      if (isNaN(parsedInt)) {
+        id = new entity.Int(id);
+      } else {
+        id = parsedInt;
+      }
     }
 
     if (is.defined(id)) {

--- a/src/entity.js
+++ b/src/entity.js
@@ -657,12 +657,7 @@ function keyFromKeyProto(keyProto) {
 
     // only convert the id to an Integer Type object if it's not already a number
     if (path.idType === 'id') {
-      var parsedInt = parseInt(id, 10);
-      if (isNaN(parsedInt)) {
-        id = new entity.Int(id);
-      } else {
-        id = parsedInt;
-      }
+      id = parseInt(id, 10) || new entity.Int(id);
     }
 
     if (is.defined(id)) {

--- a/src/entity.js
+++ b/src/entity.js
@@ -183,7 +183,7 @@ function Key(options) {
     var identifier = options.path.pop();
 
     if (is.number(identifier) || isDsInt(identifier)) {
-      this.id = identifier.value || identifier;
+      this.id = parseInt(identifier.value, 10) || identifier;
     } else if (is.string(identifier)) {
       this.name = identifier;
     }

--- a/src/entity.js
+++ b/src/entity.js
@@ -94,6 +94,14 @@ function Int(value) {
   this.value = value.toString();
 }
 
+Int.prototype.toString = function() {
+  return this.value;
+};
+
+Int.prototype.toJSON = function() {
+  return this.value;
+};
+
 entity.Int = Int;
 
 /**
@@ -183,7 +191,7 @@ function Key(options) {
     var identifier = options.path.pop();
 
     if (is.number(identifier) || isDsInt(identifier)) {
-      this.id = identifier.value || identifier;
+      this.id = identifier;
     } else if (is.string(identifier)) {
       this.name = identifier;
     }
@@ -272,7 +280,10 @@ function decodeValueProto(valueProto) {
     }
 
     case 'integerValue': {
-      return parseInt(value, 10);
+      var parsedInteger = parseInt(value, 10);
+      return Number.isSafeInteger(parsedInteger)
+        ? parsedInteger
+        : new entity.Int(value);
     }
 
     case 'entityValue': {
@@ -655,12 +666,9 @@ function keyFromKeyProto(keyProto) {
 
     var id = path[path.idType];
 
-    // only convert the id to an Integer Type object if it's not already a number
+    // convert the id to an Integer Type object
     if (path.idType === 'id') {
-      var parsedInteger = parseInt(id, 10);
-      id = Number.isSafeInteger(parsedInteger)
-        ? parsedInteger
-        : new entity.Int(id);
+      id = new entity.Int(id);
     }
 
     if (is.defined(id)) {
@@ -728,7 +736,7 @@ function keyToKeyProto(key) {
     };
 
     if (is.defined(key.id)) {
-      pathElement.id = key.id;
+      pathElement.id = key.id.value || key.id;
     }
 
     if (is.defined(key.name)) {

--- a/test/entity.js
+++ b/test/entity.js
@@ -141,7 +141,7 @@ describe('entity', function() {
     it('should assign the ID from an Int', function() {
       var id = new entity.Int(11);
       var key = new entity.Key({path: ['Kind', id]});
-      assert.strictEqual(key.id, id.value);
+      assert.strictEqual(key.id.toString(), id.value);
     });
 
     it('should assign the name', function() {
@@ -1184,7 +1184,10 @@ describe('entity', function() {
       assert.strictEqual(keyProto.path[1].name, 'name');
 
       assert.strictEqual(keyProto.path[2].kind, 'Kind3');
-      assert.strictEqual(keyProto.path[2].id, new entity.Int(3).value);
+      assert.strictEqual(
+        keyProto.path[2].id.toString(),
+        new entity.Int(3).value
+      );
       assert.strictEqual(keyProto.path[2].name, undefined);
     });
 

--- a/test/entity.js
+++ b/test/entity.js
@@ -141,7 +141,7 @@ describe('entity', function() {
     it('should assign the ID from an Int', function() {
       var id = new entity.Int(11);
       var key = new entity.Key({path: ['Kind', id]});
-      assert.strictEqual(key.id.toString(), id.value);
+      assert.strictEqual(key.id, id.value);
     });
 
     it('should assign the name', function() {
@@ -1120,7 +1120,7 @@ describe('entity', function() {
       entity.Key = function(keyOptions) {
         assert.deepEqual(keyOptions, {
           namespace: NAMESPACE,
-          path: ['Kind', new entity.Int(111), 'Kind2', 'name'],
+          path: ['Kind', 111, 'Kind2', 'name'],
         });
 
         done();
@@ -1184,10 +1184,7 @@ describe('entity', function() {
       assert.strictEqual(keyProto.path[1].name, 'name');
 
       assert.strictEqual(keyProto.path[2].kind, 'Kind3');
-      assert.strictEqual(
-        keyProto.path[2].id.toString(),
-        new entity.Int(3).value
-      );
+      assert.strictEqual(keyProto.path[2].id, new entity.Int(3).value);
       assert.strictEqual(keyProto.path[2].name, undefined);
     });
 

--- a/test/entity.js
+++ b/test/entity.js
@@ -1165,6 +1165,42 @@ describe('entity', function() {
     });
   });
 
+  describe('keyFromKeyProtoBigInt', function() {
+    var NAMESPACE = 'Namespace';
+
+    var keyProto = {
+      partitionId: {
+        namespaceId: NAMESPACE,
+        projectId: 'project-id',
+      },
+      path: [
+        {
+          idType: 'id',
+          kind: 'Kind',
+          id: '9223372036854775808',
+        },
+        {
+          idType: 'name',
+          kind: 'Kind2',
+          name: 'name',
+        },
+      ],
+    };
+
+    it('should create a proper key for the big int', function(done) {
+      entity.Key = function(keyOptions) {
+        assert.deepEqual(keyOptions, {
+          namespace: NAMESPACE,
+          path: ['Kind', {value: '9223372036854775808'}, 'Kind2', 'name'],
+        });
+
+        done();
+      };
+
+      entity.keyFromKeyProto(keyProto);
+    });
+  });
+
   describe('keyToKeyProto', function() {
     it('should handle hierarchical key definitions', function() {
       var key = new entity.Key({

--- a/test/entity.js
+++ b/test/entity.js
@@ -141,7 +141,7 @@ describe('entity', function() {
     it('should assign the ID from an Int', function() {
       var id = new entity.Int(11);
       var key = new entity.Key({path: ['Kind', id]});
-      assert.strictEqual(key.id, id.value);
+      assert.strictEqual(key.id, id);
     });
 
     it('should assign the name', function() {
@@ -1120,7 +1120,7 @@ describe('entity', function() {
       entity.Key = function(keyOptions) {
         assert.deepEqual(keyOptions, {
           namespace: NAMESPACE,
-          path: ['Kind', 111, 'Kind2', 'name'],
+          path: ['Kind', {value: '111'}, 'Kind2', 'name'],
         });
 
         done();
@@ -1162,42 +1162,6 @@ describe('entity', function() {
         assert.strictEqual(e.message, 'Ancestor keys require an id or name.');
         done();
       }
-    });
-  });
-
-  describe('keyFromKeyProtoBigInt', function() {
-    var NAMESPACE = 'Namespace';
-
-    var keyProto = {
-      partitionId: {
-        namespaceId: NAMESPACE,
-        projectId: 'project-id',
-      },
-      path: [
-        {
-          idType: 'id',
-          kind: 'Kind',
-          id: '9223372036854775808',
-        },
-        {
-          idType: 'name',
-          kind: 'Kind2',
-          name: 'name',
-        },
-      ],
-    };
-
-    it('should create a proper key for the big int', function(done) {
-      entity.Key = function(keyOptions) {
-        assert.deepEqual(keyOptions, {
-          namespace: NAMESPACE,
-          path: ['Kind', {value: '9223372036854775808'}, 'Kind2', 'name'],
-        });
-
-        done();
-      };
-
-      entity.keyFromKeyProto(keyProto);
     });
   });
 


### PR DESCRIPTION
When an integer valued key (i.e. with id) was returned, the user would get a string vs. an integer. This creates inconsistencies and a need for significant coercion as using that value in a query would result in the wrong type (i.e. a string vs. the saved int).

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
