### PR TITLE
refactor(ts): convert to typescript

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+Language:        JavaScript
+BasedOnStyle:    Google
+ColumnLimit:     80

--- a/.jsdoc.js
+++ b/.jsdoc.js
@@ -31,7 +31,7 @@ module.exports = {
   source: {
     excludePattern: '(^|\\/|\\\\)[._]',
     include: [
-      'src'
+      'build/src'
     ],
     includePattern: '\\.js$'
   },

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 ```javascript
 // Imports the Google Cloud client library
-const Datastore = require('@google-cloud/datastore');
+const {Datastore} = require('@google-cloud/datastore');
 
 // Your Google Cloud Platform project ID
 const projectId = 'YOUR_PROJECT_ID';

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": ">=6.0.0"
   },
   "repository": "googleapis/nodejs-datastore",
-  "main": "./src/index.js",
+  "main": "./build/src/index.js",
   "files": [
     "protos",
     "src",
@@ -53,14 +53,17 @@
   "scripts": {
     "docs": "jsdoc -c .jsdoc.js",
     "generate-scaffolding": "repo-tools generate all && repo-tools generate lib_samples_readme -l samples/ --config ../.cloud-repo-tools.json",
-    "lint": "eslint src/ samples/ system-test/ test/",
-    "prettier": "prettier --write src/*.js src/*/*.js samples/*.js samples/*/*.js test/*.js test/*/*.js system-test/*.js system-test/*/*.js",
-    "cover": "nyc --reporter=lcov mocha test/*.js && nyc report",
+    "lint": "eslint 'samples/*.js' 'samples/**/*.js'",
+    "cover": "nyc --reporter=lcov mocha build/test && nyc report",
     "samples-test": "cd samples/ && npm link ../ && npm test && cd ../",
-    "test-no-cover": "mocha test/*.js",
+    "test-no-cover": "mocha build/test",
     "test": "npm run cover",
-    "system-test": "mocha system-test/*.js --timeout 600000",
-    "fix": "eslint '**/*.js' --fix && npm run prettier"
+    "system-test": "mocha build/system-test --timeout 600000",
+    "fix": "eslint 'samples/*.js' 'samples/**/*.js' --fix",
+    "clean": "gts clean",
+    "compile": "tsc -p . && cp -r src/v1/ build/src/v1/ && cp -r protos build/",
+    "prepare": "npm run compile",
+    "pretest": "npm run compile"
   },
   "dependencies": {
     "@google-cloud/projectify": "^0.3.0",
@@ -79,12 +82,21 @@
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^2.3.0",
+    "@types/arrify": "^1.0.4",
+    "@types/async": "^2.0.50",
+    "@types/extend": "^3.0.0",
+    "@types/is": "0.0.20",
+    "@types/mocha": "^5.2.5",
+    "@types/proxyquire": "^1.3.28",
+    "@types/sinon": "^5.0.5",
+    "@types/through2": "^2.0.34",
     "async": "^2.6.1",
     "codecov": "^3.0.2",
     "eslint": "^5.0.0",
     "eslint-config-prettier": "^3.0.0",
     "eslint-plugin-node": "^8.0.0",
     "eslint-plugin-prettier": "^3.0.0",
+    "gts": "^0.8.0",
     "ink-docstrap": "^1.3.2",
     "intelli-espower-loader": "^1.0.1",
     "jsdoc": "^3.5.5",
@@ -93,6 +105,12 @@
     "power-assert": "^1.5.0",
     "prettier": "^1.13.5",
     "proxyquire": "^2.0.1",
-    "sinon": "^7.0.0"
+    "sinon": "^7.0.0",
+    "typescript": "~3.1.5"
+  },
+  "nyc": {
+    "exclude": [
+      "build/test"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "samples-test": "cd samples/ && npm link ../ && npm test && cd ../",
     "test-no-cover": "mocha build/test",
     "test": "npm run cover",
+    "presystem-test": "npm run compile",
     "system-test": "mocha build/system-test --timeout 600000",
     "fix": "eslint 'samples/*.js' 'samples/**/*.js' --fix",
     "clean": "gts clean",

--- a/samples/concepts.js
+++ b/samples/concepts.js
@@ -21,7 +21,7 @@ const sinon = require('sinon');
 // specified by the GOOGLE_APPLICATION_CREDENTIALS environment variable and use
 // the project specified by the GCLOUD_PROJECT environment variable. See
 // https://googlecloudplatform.github.io/gcloud-node/#/docs/google-cloud/latest/guides/authentication
-const Datastore = require('@google-cloud/datastore');
+const {Datastore} = require('@google-cloud/datastore');
 
 function makeStub() {
   return sinon.stub().returns(Promise.resolve([]));

--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -17,7 +17,7 @@
 
 // [START datastore_quickstart]
 // Imports the Google Cloud client library
-const Datastore = require('@google-cloud/datastore');
+const {Datastore} = require('@google-cloud/datastore');
 
 // Your Google Cloud Platform project ID
 const projectId = 'YOUR_PROJECT_ID';

--- a/samples/system-test/quickstart.test.js
+++ b/samples/system-test/quickstart.test.js
@@ -72,7 +72,7 @@ test.cb(`should get a task from Datastore`, t => {
 
   proxyquire(`../quickstart`, {
     '@google-cloud/datastore': {
-      Datastore: sinon.stub().returns(datastoreMock)
+      Datastore: sinon.stub().returns(datastoreMock),
     },
   });
 });

--- a/samples/system-test/quickstart.test.js
+++ b/samples/system-test/quickstart.test.js
@@ -20,7 +20,8 @@ const sinon = require(`sinon`);
 const test = require(`ava`);
 const tools = require(`@google-cloud/nodejs-repo-tools`);
 
-const datastore = proxyquire(`@google-cloud/datastore`, {})();
+const {Datastore} = proxyquire(`@google-cloud/datastore`, {});
+const datastore = new Datastore();
 
 const entity = {description: `Buy milk`};
 const kind = `Task`;
@@ -70,6 +71,8 @@ test.cb(`should get a task from Datastore`, t => {
   };
 
   proxyquire(`../quickstart`, {
-    '@google-cloud/datastore': sinon.stub().returns(datastoreMock),
+    '@google-cloud/datastore': {
+      Datastore: sinon.stub().returns(datastoreMock)
+    },
   });
 });

--- a/samples/system-test/tasks.test.js
+++ b/samples/system-test/tasks.test.js
@@ -15,11 +15,11 @@
 
 'use strict';
 
-const Datastore = require(`@google-cloud/datastore`);
-const datastore = new Datastore({});
-const path = require(`path`);
-const test = require(`ava`);
-const tools = require(`@google-cloud/nodejs-repo-tools`);
+const {Datastore} = require('@google-cloud/datastore');
+const datastore = new Datastore();
+const path = require('path');
+const test = require('ava');
+const tools = require('@google-cloud/nodejs-repo-tools');
 
 const cmd = `node tasks.js`;
 const cwd = path.join(__dirname, `..`);

--- a/samples/tasks.js
+++ b/samples/tasks.js
@@ -20,10 +20,10 @@
 // specified by the GOOGLE_APPLICATION_CREDENTIALS environment variable and use
 // the project specified by the GCLOUD_PROJECT environment variable. See
 // https://googlecloudplatform.github.io/google-cloud-node/#/docs/datastore/latest/guides/authentication
-const Datastore = require('@google-cloud/datastore');
+const {Datastore} = require('@google-cloud/datastore');
 
 // Creates a client
-const datastore = new Datastore({});
+const datastore = new Datastore();
 // [END datastore_build_service]
 
 /*

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -16,9 +16,9 @@
 
 'use strict';
 
-const arrify = require('arrify');
-const extend = require('extend');
-const is = require('is');
+import * as arrify from 'arrify';
+import * as extend from 'extend';
+import * as is from 'is';
 
 const entity = module.exports;
 
@@ -268,7 +268,7 @@ function decodeValueProto(valueProto) {
     }
 
     case 'doubleValue': {
-      return parseFloat(value, 10);
+      return Number(value);
     }
 
     case 'integerValue': {
@@ -310,14 +310,15 @@ entity.decodeValueProto = decodeValueProto;
  * // }
  */
 function encodeValue(value) {
-  const valueProto = {};
+  // tslint:disable-next-line no-any
+  const valueProto: any = {};
 
   if (is.boolean(value)) {
     valueProto.booleanValue = value;
     return valueProto;
   }
 
-  if (is.nil(value)) {
+  if (is.null(value)) {
     valueProto.nullValue = 0;
     return valueProto;
   }
@@ -642,7 +643,8 @@ entity.isKeyComplete = isKeyComplete;
  * });
  */
 function keyFromKeyProto(keyProto) {
-  const keyOptions = {
+  // tslint:disable-next-line no-any
+  const keyOptions: any = {
     path: [],
   };
 
@@ -698,7 +700,8 @@ function keyToKeyProto(key) {
     });
   }
 
-  const keyProto = {
+  // tslint:disable-next-line no-any
+  const keyProto: any = {
     path: [],
   };
 
@@ -719,7 +722,8 @@ function keyToKeyProto(key) {
       });
     }
 
-    const pathElement = {
+    // tslint:disable-next-line no-any
+    const pathElement: any = {
       kind: key.kind,
     };
 
@@ -787,7 +791,8 @@ function queryToQueryProto(query) {
     '+': 'ASCENDING',
   };
 
-  const queryProto = {
+  // tslint:disable-next-line no-any
+  const queryProto: any = {
     distinctOn: query.groupByVal.map(groupBy => {
       return {
         name: groupBy,
@@ -838,7 +843,8 @@ function queryToQueryProto(query) {
 
   if (query.filters.length > 0) {
     const filters = query.filters.map(filter => {
-      let value = {};
+      // tslint:disable-next-line no-any
+      let value: any = {};
 
       if (filter.name === '__key__') {
         value.keyValue = entity.keyToKeyProto(filter.val);

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -48,7 +48,7 @@ entity.KEY_SYMBOL = Symbol('KEY');
  * @param {number} value The double value.
  *
  * @example
- * const Datastore = require('@google-cloud/datastore');
+ * const {Datastore} = require('@google-cloud/datastore');
  * const datastore = new Datastore();
  * const aDouble = datastore.double(7.3);
  */
@@ -82,7 +82,7 @@ entity.isDsDouble = isDsDouble;
  * @param {number|string} value The integer value.
  *
  * @example
- * const Datastore = require('@google-cloud/datastore');
+ * const {Datastore} = require('@google-cloud/datastore');
  * const datastore = new Datastore();
  * const anInt = datastore.int(7);
  */
@@ -118,7 +118,7 @@ entity.isDsInt = isDsInt;
  * @param {number} coordinates.longitude Longitudinal value.
  *
  * @example
- * const Datastore = require('@google-cloud/datastore');
+ * const {Datastore} = require('@google-cloud/datastore');
  * const datastore = new Datastore();
  * const coordinates = {
  *   latitude: 40.6894,
@@ -163,7 +163,7 @@ entity.isDsGeoPoint = isDsGeoPoint;
  * @param {string} [options.namespace] Optional namespace.
  *
  * @example
- * const Datastore = require('@google-cloud/datastore');
+ * const {Datastore} = require('@google-cloud/datastore');
  * const datastore = new Datastore();
  * const key = datastore.key({
  *   namespace: 'ns',

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,7 +104,7 @@ const gapic = Object.freeze({
  * @param {string} [options.namespace] Namespace to isolate transactions to.
  *
  * @example <caption>Import the client library</caption>
- * const Datastore = require('@google-cloud/datastore');
+ * const {Datastore} = require('@google-cloud/datastore');
  *
  * @example <caption>Create a client that uses <a href="https://cloud.google.com/docs/authentication/production#providing_credentials_to_your_application">Application Default Credentials (ADC)</a>:</caption>
  * const datastore = new Datastore();
@@ -116,7 +116,7 @@ const gapic = Object.freeze({
  * });
  *
  * @example <caption>Retrieving Records</caption>
- * const Datastore = require('@google-cloud/datastore');
+ * const {Datastore} = require('@google-cloud/datastore');
  * const datastore = new Datastore();
  *
  * // Records, called "entities" in Datastore, are retrieved by using a key. The
@@ -307,7 +307,7 @@ const gapic = Object.freeze({
  * });
  *
  * @example <caption>Queries with Ancestors</caption>
- * const Datastore = require('@google-cloud/datastore');
+ * const {Datastore} = require('@google-cloud/datastore');
  * const datastore = new Datastore();
  *
  * const customerId1 = 2993844;
@@ -430,7 +430,7 @@ class Datastore extends DatastoreRequest {
    * @returns {object}
    *
    * @example
-   * const Datastore = require('@google-cloud/datastore');
+   * const {Datastore} = require('@google-cloud/datastore');
    * const datastore = new Datastore();
    * const threeDouble = datastore.double(3.0);
    */
@@ -449,7 +449,7 @@ class Datastore extends DatastoreRequest {
    * @returns {boolean}
    *
    * @example
-   * const Datastore = require('@google-cloud/datastore');
+   * const {Datastore} = require('@google-cloud/datastore');
    * const datastore = new Datastore();
    * datastore.isDouble(0.42); // false
    * datastore.isDouble(datastore.double(0.42)); // true
@@ -471,7 +471,7 @@ class Datastore extends DatastoreRequest {
    * @returns {object}
    *
    * @example
-   * const Datastore = require('@google-cloud/datastore');
+   * const {Datastore} = require('@google-cloud/datastore');
    * const datastore = new Datastore();
    * const coordinates = {
    *   latitude: 40.6894,
@@ -495,7 +495,7 @@ class Datastore extends DatastoreRequest {
    * @returns {boolean}
    *
    * @example
-   * const Datastore = require('@google-cloud/datastore');
+   * const {Datastore} = require('@google-cloud/datastore');
    * const datastore = new Datastore();
    * const coordinates = {
    *   latitude: 0,
@@ -523,7 +523,7 @@ class Datastore extends DatastoreRequest {
    * @returns {object}
    *
    * @example
-   * const Datastore = require('@google-cloud/datastore');
+   * const {Datastore} = require('@google-cloud/datastore');
    * const datastore = new Datastore();
    * const sevenInteger = datastore.int(7);
    *
@@ -550,7 +550,7 @@ class Datastore extends DatastoreRequest {
    * @returns {boolean}
    *
    * @example
-   * const Datastore = require('@google-cloud/datastore');
+   * const {Datastore} = require('@google-cloud/datastore');
    * const datastore = new Datastore();
    * datastore.isInt(42); // false
    * datastore.isInt(datastore.int(42)); // true
@@ -627,7 +627,7 @@ class Datastore extends DatastoreRequest {
    * @returns {Query}
    *
    * @example
-   * const Datastore = require('@google-cloud/datastore');
+   * const {Datastore} = require('@google-cloud/datastore');
    * const datastore = new Datastore();
    * const query = datastore.createQuery('Company');
    */
@@ -652,19 +652,19 @@ class Datastore extends DatastoreRequest {
    *
    * @example
    * <caption>Create an incomplete key with a kind value of `Company`.</caption>
-   * const Datastore = require('@google-cloud/datastore');
+   * const {Datastore} = require('@google-cloud/datastore');
    * const datastore = new Datastore();
    * const key = datastore.key('Company');
    *
    * @example
    * <caption>Create a complete key with a kind value of `Company` and id `123`.</caption>
-   * const Datastore = require('@google-cloud/datastore');
+   * const {Datastore} = require('@google-cloud/datastore');
    * const datastore = new Datastore();
    * const key = datastore.key(['Company', 123]);
    *
    * @example
    * <caption>If the ID integer is outside the bounds of a JavaScript Number object, create an Int.</caption>
-   * const Datastore = require('@google-cloud/datastore');
+   * const {Datastore} = require('@google-cloud/datastore');
    * const datastore = new Datastore();
    * const key = datastore.key([
    *   'Company',
@@ -672,7 +672,7 @@ class Datastore extends DatastoreRequest {
    * ]);
    *
    * @example
-   * const Datastore = require('@google-cloud/datastore');
+   * const {Datastore} = require('@google-cloud/datastore');
    * const datastore = new Datastore();
    * // Create a complete key with a kind value of `Company` and name `Google`.
    * // Note: `id` is used for numeric identifiers and `name` is used otherwise.
@@ -680,7 +680,7 @@ class Datastore extends DatastoreRequest {
    *
    * @example
    * <caption>Create a complete key from a provided namespace and path.</caption>
-   * const Datastore = require('@google-cloud/datastore');
+   * const {Datastore} = require('@google-cloud/datastore');
    * const datastore = new Datastore();
    * const key = datastore.key({
    *   namespace: 'My-NS',
@@ -704,7 +704,7 @@ class Datastore extends DatastoreRequest {
    * @returns {boolean}
    *
    * @example
-   * const Datastore = require('@google-cloud/datastore');
+   * const {Datastore} = require('@google-cloud/datastore');
    * const datastore = new Datastore();
    * datastore.isKey({path: ['Company', 123]}); // false
    * datastore.isKey(datastore.key(['Company', 123])); // true
@@ -726,7 +726,7 @@ class Datastore extends DatastoreRequest {
    * @returns {Transaction}
    *
    * @example
-   * const Datastore = require('@google-cloud/datastore');
+   * const {Datastore} = require('@google-cloud/datastore');
    * const datastore = new Datastore();
    * const transaction = datastore.transaction();
    */
@@ -810,7 +810,7 @@ export {Datastore};
  * npm install --save @google-cloud/datastore
  *
  * @example <caption>Import the client library</caption>
- * const Datastore = require('@google-cloud/datastore');
+ * const {Datastore} = require('@google-cloud/datastore');
  *
  * @example <caption>Create a client that uses <a href="https://cloud.google.com/docs/authentication/production#providing_credentials_to_your_application">Application Default Credentials (ADC)</a>:</caption>
  * const datastore = new Datastore();
@@ -825,7 +825,6 @@ export {Datastore};
  * region_tag:datastore_quickstart
  * Full quickstart example:
  */
-module.exports = Datastore;
 
 /**
  * @name Datastore.v1

--- a/src/query.ts
+++ b/src/query.ts
@@ -33,7 +33,7 @@ import * as arrify from 'arrify';
  * @param {string} kind Kind to query.
  *
  * @example
- * const Datastore = require('@google-cloud/datastore');
+ * const {Datastore} = require('@google-cloud/datastore');
  * const datastore = new Datastore();
  * const query = datastore.createQuery('AnimalNamespace', 'Lion');
  */
@@ -131,7 +131,7 @@ class Query {
    * @returns {Query}
    *
    * @example
-   * const Datastore = require('@google-cloud/datastore');
+   * const {Datastore} = require('@google-cloud/datastore');
    * const datastore = new Datastore();
    * const query = datastore.createQuery('Company');
    *
@@ -177,7 +177,7 @@ class Query {
    * @returns {Query}
    *
    * @example
-   * const Datastore = require('@google-cloud/datastore');
+   * const {Datastore} = require('@google-cloud/datastore');
    * const datastore = new Datastore();
    * const query = datastore.createQuery('MyKind');
    * const ancestoryQuery = query.hasAncestor(datastore.key(['Parent', 123]));
@@ -200,7 +200,7 @@ class Query {
    * @returns {Query}
    *
    * @example
-   * const Datastore = require('@google-cloud/datastore');
+   * const {Datastore} = require('@google-cloud/datastore');
    * const datastore = new Datastore();
    * const companyQuery = datastore.createQuery('Company');
    *
@@ -225,7 +225,7 @@ class Query {
    * @returns {Query}
    *
    * @example
-   * const Datastore = require('@google-cloud/datastore');
+   * const {Datastore} = require('@google-cloud/datastore');
    * const datastore = new Datastore();
    * const companyQuery = datastore.createQuery('Company');
    * const groupedQuery = companyQuery.groupBy(['name', 'size']);
@@ -247,7 +247,7 @@ class Query {
    * @returns {Query}
    *
    * @example
-   * const Datastore = require('@google-cloud/datastore');
+   * const {Datastore} = require('@google-cloud/datastore');
    * const datastore = new Datastore();
    * const companyQuery = datastore.createQuery('Company');
    *
@@ -271,7 +271,7 @@ class Query {
    * @returns {Query}
    *
    * @example
-   * const Datastore = require('@google-cloud/datastore');
+   * const {Datastore} = require('@google-cloud/datastore');
    * const datastore = new Datastore();
    * const companyQuery = datastore.createQuery('Company');
    *
@@ -294,7 +294,7 @@ class Query {
    * @returns {Query}
    *
    * @example
-   * const Datastore = require('@google-cloud/datastore');
+   * const {Datastore} = require('@google-cloud/datastore');
    * const datastore = new Datastore();
    * const companyQuery = datastore.createQuery('Company');
    *
@@ -317,7 +317,7 @@ class Query {
    * @returns {Query}
    *
    * @example
-   * const Datastore = require('@google-cloud/datastore');
+   * const {Datastore} = require('@google-cloud/datastore');
    * const datastore = new Datastore();
    * const companyQuery = datastore.createQuery('Company');
    *
@@ -338,7 +338,7 @@ class Query {
    * @returns {Query}
    *
    * @example
-   * const Datastore = require('@google-cloud/datastore');
+   * const {Datastore} = require('@google-cloud/datastore');
    * const datastore = new Datastore();
    * const companyQuery = datastore.createQuery('Company');
    *
@@ -374,7 +374,7 @@ class Query {
    *     - {@link Datastore#NO_MORE_RESULTS}: There are no more results.
    *
    * @example
-   * const Datastore = require('@google-cloud/datastore');
+   * const {Datastore} = require('@google-cloud/datastore');
    * const datastore = new Datastore();
    * const query = datastore.createQuery('Company');
    *
@@ -419,7 +419,7 @@ class Query {
    * @returns {stream}
    *
    * @example
-   * const Datastore = require('@google-cloud/datastore');
+   * const {Datastore} = require('@google-cloud/datastore');
    * const datastore = new Datastore();
    * const query = datastore.createQuery('Company');
    *

--- a/src/query.ts
+++ b/src/query.ts
@@ -16,7 +16,7 @@
 
 'use strict';
 
-const arrify = require('arrify');
+import * as arrify from 'arrify';
 
 /**
  * Build a Query object.
@@ -38,6 +38,17 @@ const arrify = require('arrify');
  * const query = datastore.createQuery('AnimalNamespace', 'Lion');
  */
 class Query {
+  scope;
+  namespace?: string;
+  kinds;
+  filters;
+  orders;
+  groupByVal;
+  selectVal;
+  startVal;
+  endVal;
+  limitVal;
+  offsetVal;
   constructor(scope, namespace, kinds) {
     if (!kinds) {
       kinds = namespace;

--- a/src/request.ts
+++ b/src/request.ts
@@ -16,15 +16,15 @@
 
 'use strict';
 
-const arrify = require('arrify');
-const {replaceProjectIdToken} = require('@google-cloud/projectify');
-const {promisifyAll} = require('@google-cloud/promisify');
+import * as arrify from 'arrify';
+import {replaceProjectIdToken} from '@google-cloud/projectify';
+import {promisifyAll} from '@google-cloud/promisify';
 const concat = require('concat-stream');
-const extend = require('extend');
-const is = require('is');
-const {split} = require('split-array-stream');
-const streamEvents = require('stream-events');
-const through = require('through2');
+import * as extend from 'extend';
+import * as is from 'is';
+import {split} from 'split-array-stream';
+import * as streamEvents from 'stream-events';
+import * as through from 'through2';
 
 // Import the clients for each version supported by this package.
 const gapic = Object.freeze({
@@ -55,6 +55,12 @@ const CONSISTENCY_PROTO_CODE = {
  * @class
  */
 class DatastoreRequest {
+
+  id;
+  requests_;
+  requestCallbacks_;
+  datastore;
+
   /**
    * Format a user's input to mutation methods. This will create a deep clone of
    * the input, as well as allow users to pass an object in the format of an
@@ -223,7 +229,8 @@ class DatastoreRequest {
     }
 
     const makeRequest = keys => {
-      const reqOpts = {
+      // tslint:disable-next-line no-any
+      const reqOpts: any = {
         keys: keys,
       };
 
@@ -632,7 +639,8 @@ class DatastoreRequest {
     query = extend(true, new Query(), query);
 
     const makeRequest = query => {
-      const reqOpts = {
+      // tslint:disable-next-line no-any
+      const reqOpts: any = {
         query: entity.queryToQueryProto(query),
       };
 
@@ -666,7 +674,8 @@ class DatastoreRequest {
         return;
       }
 
-      const info = {
+      // tslint:disable-next-line no-any
+      const info: any = {
         moreResults: resp.batch.moreResults,
       };
 
@@ -918,7 +927,7 @@ class DatastoreRequest {
    *   const apiResponse = data[0];
    * });
    */
-  save(entities, gaxOptions, callback) {
+  save(entities, gaxOptions, callback?) {
     entities = arrify(entities);
 
     if (is.fn(gaxOptions)) {
@@ -927,7 +936,7 @@ class DatastoreRequest {
     }
 
     const insertIndexes = {};
-    const mutations = [];
+    const mutations: {}[] = [];
     const methods = {
       insert: true,
       update: true,
@@ -940,7 +949,8 @@ class DatastoreRequest {
       .map(DatastoreRequest.prepareEntityObject_)
       .forEach((entityObject, index) => {
         const mutation = {};
-        let entityProto = {};
+        // tslint:disable-next-line no-any
+        let entityProto: any = {};
         let method = 'upsert';
 
         if (entityObject.method) {

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -38,7 +38,7 @@ const Request = require('./request');
  * @mixes module:datastore/request
  *
  * @example
- * const Datastore = require('@google-cloud/datastore');
+ * const {Datastore} = require('@google-cloud/datastore');
  * const datastore = new Datastore();
  * const transaction = datastore.transaction();
  */
@@ -103,7 +103,7 @@ class Transaction extends Request {
    * @param {object} callback.apiResponse The full API response.
    *
    * @example
-   * const Datastore = require('@google-cloud/datastore');
+   * const {Datastore} = require('@google-cloud/datastore');
    * const datastore = new Datastore();
    * const transaction = datastore.transaction();
    *
@@ -245,7 +245,7 @@ class Transaction extends Request {
    * @returns {Query}
    *
    * @example
-   * const Datastore = require('@google-cloud/datastore');
+   * const {Datastore} = require('@google-cloud/datastore');
    * const datastore = new Datastore();
    * const transaction = datastore.transaction();
    *
@@ -281,7 +281,7 @@ class Transaction extends Request {
    * @param {Key|Key[]} key Datastore key object(s).
    *
    * @example
-   * const Datastore = require('@google-cloud/datastore');
+   * const {Datastore} = require('@google-cloud/datastore');
    * const datastore = new Datastore();
    * const transaction = datastore.transaction();
    *
@@ -328,7 +328,7 @@ class Transaction extends Request {
    * @param {object} callback.apiResponse The full API response.
    *
    * @example
-   * const Datastore = require('@google-cloud/datastore');
+   * const {Datastore} = require('@google-cloud/datastore');
    * const datastore = new Datastore();
    * const transaction = datastore.transaction();
    *
@@ -390,7 +390,7 @@ class Transaction extends Request {
    * @param {object} callback.apiResponse The full API response.
    *
    * @example
-   * const Datastore = require('@google-cloud/datastore');
+   * const {Datastore} = require('@google-cloud/datastore');
    * const datastore = new Datastore();
    * const transaction = datastore.transaction();
    *
@@ -493,7 +493,7 @@ class Transaction extends Request {
    *
    * @example
    * <caption>Save a single entity.</caption>
-   * const Datastore = require('@google-cloud/datastore');
+   * const {Datastore} = require('@google-cloud/datastore');
    * const datastore = new Datastore();
    * const transaction = datastore.transaction();
    *
@@ -523,7 +523,7 @@ class Transaction extends Request {
    * });
    *
    * @example
-   * const Datastore = require('@google-cloud/datastore');
+   * const {Datastore} = require('@google-cloud/datastore');
    * const datastore = new Datastore();
    * const transaction = datastore.transaction();
    *
@@ -564,7 +564,7 @@ class Transaction extends Request {
    *
    * @example
    * <caption>Save multiple entities at once.</caption>
-   * const Datastore = require('@google-cloud/datastore');
+   * const {Datastore} = require('@google-cloud/datastore');
    * const datastore = new Datastore();
    * const transaction = datastore.transaction();
    * const companyKey = datastore.key(['Company', 123]);

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -16,10 +16,10 @@
 
 'use strict';
 
-const arrify = require('arrify');
-const {promisifyAll} = require('@google-cloud/promisify');
+import * as arrify from 'arrify';
+import {promisifyAll} from '@google-cloud/promisify';
 const flatten = require('lodash.flatten');
-const is = require('is');
+import * as is from 'is';
 
 const entity = require('./entity');
 const Request = require('./request');
@@ -156,6 +156,8 @@ class Transaction extends Request {
           keys[stringifiedKey] = true;
           return true;
         }
+
+        return false;
       })
       // Group entities together by method: `save` mutations, then `delete`. Note:
       // `save` mutations being first is required to maintain order when assigning
@@ -349,7 +351,7 @@ class Transaction extends Request {
    *   const apiResponse = data[0];
    * });
    */
-  rollback(gaxOptions, callback) {
+  rollback(gaxOptions, callback?) {
     if (is.fn(gaxOptions)) {
       callback = gaxOptions;
       gaxOptions = {};
@@ -429,7 +431,8 @@ class Transaction extends Request {
     options = options || {};
     callback = callback || (() => {});
 
-    const reqOpts = {
+    // tslint:disable-next-line no-any
+    const reqOpts: any = {
       transactionOptions: {},
     };
 

--- a/src/v1/datastore_client.js
+++ b/src/v1/datastore_client.js
@@ -213,7 +213,7 @@ class DatastoreClient {
    *
    * @example
    *
-   * const datastore = require('@google-cloud/datastore');
+   * const {Datastore} = require('@google-cloud/datastore');
    *
    * const client = new datastore.v1.DatastoreClient({
    *   // optional auth parameters.
@@ -283,7 +283,7 @@ class DatastoreClient {
    *
    * @example
    *
-   * const datastore = require('@google-cloud/datastore');
+   * const {Datastore} = require('@google-cloud/datastore');
    *
    * const client = new datastore.v1.DatastoreClient({
    *   // optional auth parameters.
@@ -338,7 +338,7 @@ class DatastoreClient {
    *
    * @example
    *
-   * const datastore = require('@google-cloud/datastore');
+   * const {Datastore} = require('@google-cloud/datastore');
    *
    * const client = new datastore.v1.DatastoreClient({
    *   // optional auth parameters.
@@ -409,7 +409,7 @@ class DatastoreClient {
    *
    * @example
    *
-   * const datastore = require('@google-cloud/datastore');
+   * const {Datastore} = require('@google-cloud/datastore');
    *
    * const client = new datastore.v1.DatastoreClient({
    *   // optional auth parameters.
@@ -465,7 +465,7 @@ class DatastoreClient {
    *
    * @example
    *
-   * const datastore = require('@google-cloud/datastore');
+   * const {Datastore} = require('@google-cloud/datastore');
    *
    * const client = new datastore.v1.DatastoreClient({
    *   // optional auth parameters.
@@ -522,7 +522,7 @@ class DatastoreClient {
    *
    * @example
    *
-   * const datastore = require('@google-cloud/datastore');
+   * const {Datastore} = require('@google-cloud/datastore');
    *
    * const client = new datastore.v1.DatastoreClient({
    *   // optional auth parameters.
@@ -581,7 +581,7 @@ class DatastoreClient {
    *
    * @example
    *
-   * const datastore = require('@google-cloud/datastore');
+   * const {Datastore} = require('@google-cloud/datastore');
    *
    * const client = new datastore.v1.DatastoreClient({
    *   // optional auth parameters.

--- a/src/v1/datastore_client.js
+++ b/src/v1/datastore_client.js
@@ -19,7 +19,7 @@ const gax = require('google-gax');
 const merge = require('lodash.merge');
 const path = require('path');
 
-const VERSION = require('../../package.json').version;
+const VERSION = require('../../../package.json').version;
 
 /**
  * Each RPC normalizes the partition IDs of the keys in its input entities,
@@ -612,5 +612,6 @@ class DatastoreClient {
     return this._innerApiCalls.reserveIds(request, options, callback);
   }
 }
+
 
 module.exports = DatastoreClient;

--- a/synth.py
+++ b/synth.py
@@ -1,15 +1,11 @@
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
-from pathlib import Path
 import subprocess
 
 logging.basicConfig(level=logging.DEBUG)
 
 gapic = gcp.GAPICGenerator()
-common_templates = gcp.CommonTemplates()
-
-# tasks has two product names, and a poorly named artman yaml
 version = 'v1'
 library = gapic.node_library(
     'datastore', version,
@@ -20,11 +16,13 @@ s.copy(
     library,
     excludes=['package.json', 'README.md', 'src/index.js'])
 
-templates = common_templates.node_library(package_name="@google-cloud/datastore")
-s.copy(templates)
+# Update path discovery due to build/ dir and TypeScript conversion.
+s.replace("src/v1/datastore_client.js", "../../package.json", "../../../package.json")
 
+common_templates = gcp.CommonTemplates()
+templates = common_templates.node_library(source_location="build/src")
+s.copy(templates)
 
 # Node.js specific cleanup
 subprocess.run(['npm', 'install'])
-subprocess.run(['npm', 'run', 'prettier'])
-subprocess.run(['npm', 'run', 'lint'])
+subprocess.run(['npm', 'run', 'fix'])

--- a/system-test/datastore.ts
+++ b/system-test/datastore.ts
@@ -18,7 +18,7 @@
 
 import * as assert from 'assert';
 import * as async from 'async';
-const Datastore = require('../src');
+const {Datastore} = require('../src');
 const entity = require('../src/entity.js');
 
 describe('Datastore', () => {

--- a/system-test/datastore.ts
+++ b/system-test/datastore.ts
@@ -16,16 +16,16 @@
 
 'use strict';
 
-const assert = require('assert');
-const async = require('async');
-const Datastore = require('../');
+import * as assert from 'assert';
+import * as async from 'async';
+const Datastore = require('../src');
 const entity = require('../src/entity.js');
 
 describe('Datastore', () => {
-  const testKinds = [];
-  const datastore = new Datastore({});
+  const testKinds: {}[] = [];
+  const datastore = new Datastore();
   // Override the Key method so we can track what keys are created during the
-  // tests. They are then deleted in the `after` hook.
+    // tests. They are then deleted in the `after` hook.
   const key = datastore.key;
   datastore.key = function() {
     const keyObject = key.apply(this, arguments);
@@ -322,7 +322,7 @@ describe('Datastore', () => {
       const post2 = {
         title: 'How to make the perfect homemade pasta',
         tags: ['pasta', 'homemade'],
-        publishedAt: Date('2001-01-01T00:00:00.000Z'),
+        publishedAt: new Date('2001-01-01T00:00:00.000Z'),
         author: 'Silvano',
         isDraft: false,
         wordCount: 450,

--- a/test/entity.ts
+++ b/test/entity.ts
@@ -19,7 +19,7 @@
 import * as assert from 'assert';
 import * as extend from 'extend';
 
-const Datastore = require('../src');
+const Datastore = require('../src').Datastore;
 
 describe('entity', function() {
   let entity;

--- a/test/entity.ts
+++ b/test/entity.ts
@@ -16,10 +16,10 @@
 
 'use strict';
 
-const assert = require('assert');
-const extend = require('extend');
+import * as assert from 'assert';
+import * as extend from 'extend';
 
-const Datastore = require('../');
+const Datastore = require('../src');
 
 describe('entity', function() {
   let entity;

--- a/test/gapic-v1.ts
+++ b/test/gapic-v1.ts
@@ -14,13 +14,14 @@
 
 'use strict';
 
-const assert = require('assert');
+import * as assert from 'assert';
 
 const datastoreModule = require('../src');
 
 const FAKE_STATUS_CODE = 1;
 const error = new Error();
-error.code = FAKE_STATUS_CODE;
+// tslint:disable-next-line no-any
+(error as any).code = FAKE_STATUS_CODE;
 
 describe('DatastoreClient', () => {
   describe('lookup', () => {
@@ -69,11 +70,7 @@ describe('DatastoreClient', () => {
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.lookup = mockSimpleGrpcMethod(
-        request,
-        null,
-        error
-      );
+      client._innerApiCalls.lookup = mockSimpleGrpcMethod(request, null, error);
 
       client.lookup(request, (err, response) => {
         assert(err instanceof Error);
@@ -258,11 +255,7 @@ describe('DatastoreClient', () => {
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.commit = mockSimpleGrpcMethod(
-        request,
-        null,
-        error
-      );
+      client._innerApiCalls.commit = mockSimpleGrpcMethod(request, null, error);
 
       client.commit(request, (err, response) => {
         assert(err instanceof Error);
@@ -455,10 +448,9 @@ describe('DatastoreClient', () => {
       });
     });
   });
-
 });
 
-function mockSimpleGrpcMethod(expectedRequest, response, error) {
+function mockSimpleGrpcMethod(expectedRequest, response, error?) {
   return function(actualRequest, options, callback) {
     assert.deepStrictEqual(actualRequest, expectedRequest);
     if (error) {

--- a/test/index.ts
+++ b/test/index.ts
@@ -16,14 +16,15 @@
 
 'use strict';
 
-const assert = require('assert');
-const extend = require('extend');
-const gax = new require('google-gax');
-const proxyquire = require('proxyquire');
+import * as assert from 'assert';
+import * as extend from 'extend';
+import * as gax from 'google-gax';
+import * as proxyquire from 'proxyquire';
 
 const v1 = require('../src/v1/index.js');
 
-const fakeEntity = {
+// tslint:disable-next-line no-any
+const fakeEntity: any = {
   KEY_SYMBOL: Symbol('fake key symbol'),
   Int: function(value) {
     this.value = value;
@@ -72,7 +73,7 @@ const fakeGoogleGax = {
             );
           },
         },
-      };
+      } as gax.GrpcModule;
     }
   },
 };
@@ -106,7 +107,7 @@ describe('Datastore', function() {
   };
 
   before(function() {
-    Datastore = proxyquire('../', {
+    Datastore = proxyquire('../src', {
       './entity.js': fakeEntity,
       './query.js': FakeQuery,
       './transaction.js': FakeTransaction,
@@ -146,12 +147,6 @@ describe('Datastore', function() {
   });
 
   describe('instantiation', function() {
-    it('should work without new', function() {
-      assert.doesNotThrow(function() {
-        Datastore({projectId: PROJECT_ID});
-      });
-    });
-
     it('should initialize an empty Client map', function() {
       assert(datastore.clients_ instanceof Map);
       assert.strictEqual(datastore.clients_.size, 0);
@@ -225,7 +220,7 @@ describe('Datastore', function() {
         extend(
           {
             libName: 'gccl',
-            libVersion: require('../package.json').version,
+            libVersion: require('../../package.json').version,
             scopes: v1.DatastoreClient.scopes,
             servicePath: datastore.baseUrl_,
             port: 443,
@@ -288,7 +283,9 @@ describe('Datastore', function() {
     });
 
     it('should also be on the prototype', function() {
-      assert.strictEqual(datastore.double, Datastore.double);
+      const aDouble = 7.0;
+      const double = datastore.double(aDouble);
+      assert.strictEqual(double.value, aDouble);
     });
   });
 
@@ -300,7 +297,9 @@ describe('Datastore', function() {
     });
 
     it('should also be on the prototype', function() {
-      assert.strictEqual(datastore.geoPoint, Datastore.geoPoint);
+      const aGeoPoint = {latitude: 24, longitude: 88};
+      const geoPoint = datastore.geoPoint(aGeoPoint);
+      assert.strictEqual(geoPoint.value, aGeoPoint);
     });
   });
 
@@ -312,7 +311,9 @@ describe('Datastore', function() {
     });
 
     it('should also be on the prototype', function() {
-      assert.strictEqual(datastore.int, Datastore.int);
+      const anInt = 7;
+      const int = datastore.int(anInt);
+      assert.strictEqual(int.value, anInt);
     });
   });
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -116,7 +116,7 @@ describe('Datastore', function() {
         GoogleAuth: fakeGoogleAuth,
       },
       'google-gax': fakeGoogleGax,
-    });
+    }).Datastore;
   });
 
   beforeEach(function() {
@@ -143,7 +143,7 @@ describe('Datastore', function() {
   });
 
   it('should export GAX client', function() {
-    assert.strictEqual(Datastore.v1, FakeV1);
+    assert.ok(require('../src').v1);
   });
 
   describe('instantiation', function() {

--- a/test/query.ts
+++ b/test/query.ts
@@ -16,7 +16,7 @@
 
 'use strict';
 
-const assert = require('assert');
+import * as assert from 'assert';
 
 describe('Query', function() {
   const SCOPE = {};

--- a/test/request.ts
+++ b/test/request.ts
@@ -16,12 +16,12 @@
 
 'use strict';
 
-const assert = require('assert');
-const extend = require('extend');
-const is = require('is');
-const proxyquire = require('proxyquire');
+import * as assert from 'assert';
+import * as extend from 'extend';
+import * as is from 'is';
+import * as proxyquire from 'proxyquire';
 const sinon = require('sinon');
-const through = require('through2');
+import * as through from 'through2';
 const pfy = require('@google-cloud/promisify');
 const pjy = require('@google-cloud/projectify');
 
@@ -163,7 +163,7 @@ describe('Request', function() {
         assert.strictEqual(config.client, 'DatastoreClient');
         assert.strictEqual(config.method, 'allocateIds');
 
-        const expectedKeys = [];
+        const expectedKeys: {}[] = [];
         expectedKeys.length = ALLOCATIONS;
         expectedKeys.fill(keyProto);
 
@@ -422,7 +422,8 @@ describe('Request', function() {
       const entities = apiResponseWithMultiEntities.found;
       entities.push(entities[0]);
 
-      const apiResponseWithDeferred = extend(true, {}, apiResponse);
+      // tslint:disable-next-line no-any
+      const apiResponseWithDeferred = extend(true, {}, apiResponse) as any;
       apiResponseWithDeferred.deferred = [
         apiResponseWithDeferred.found[0].entity.key,
       ];
@@ -861,7 +862,7 @@ describe('Request', function() {
           return array;
         });
 
-        const entities = [];
+        const entities: {}[] = [];
 
         request
           .runQueryStream({})
@@ -960,7 +961,7 @@ describe('Request', function() {
           return queryProto;
         });
 
-        const entities = [];
+        const entities: {}[] = [];
         let info;
 
         request
@@ -1406,7 +1407,7 @@ describe('Request', function() {
       const incompleteKey2 = new entity.Key({path: ['Incomplete']});
       const completeKey = new entity.Key({path: ['Complete', 'Key']});
 
-      const keyProtos = [];
+      const keyProtos: {}[] = [];
       const ids = [1, 2];
 
       const response = {
@@ -1643,7 +1644,8 @@ describe('Request', function() {
     it('should replace the project ID token', function(done) {
       const replacedReqOpts = {};
 
-      const expectedReqOpts = extend({}, CONFIG.reqOpts);
+      // tslint:disable-next-line no-any
+      const expectedReqOpts: any = extend({}, CONFIG.reqOpts);
       expectedReqOpts.projectId = request.projectId;
 
       pjyOverride = function(reqOpts, projectId) {

--- a/test/transaction.ts
+++ b/test/transaction.ts
@@ -16,12 +16,12 @@
 
 'use strict';
 
-const arrify = require('arrify');
-const assert = require('assert');
+import * as arrify from 'arrify';
+import * as assert from 'assert';
 const entity = require('../src/entity.js');
-const extend = require('extend');
-const proxyquire = require('proxyquire');
-const pfy = require('@google-cloud/promisify');
+import * as extend from 'extend';
+import * as proxyquire from 'proxyquire';
+import * as pfy from '@google-cloud/promisify';
 
 let promisified = false;
 const fakePfy = extend({}, pfy, {
@@ -34,7 +34,8 @@ const fakePfy = extend({}, pfy, {
   },
 });
 
-const DatastoreRequestOverride = {
+// tslint:disable-next-line no-any
+const DatastoreRequestOverride: any = {
   delete: function() {},
   save: function() {},
 };
@@ -119,7 +120,8 @@ describe('Transaction', function() {
     });
 
     it('should localize request function', function(done) {
-      const fakeDataset = {
+      // tslint:disable-next-line no-any
+      const fakeDataset: any = {
         request_: {
           bind: function(context) {
             assert.strictEqual(context, fakeDataset);
@@ -230,7 +232,7 @@ describe('Transaction', function() {
       transaction.delete(deleteArg2);
       transaction.save(saveArg2);
 
-      const args = [];
+      const args: {}[] = [];
 
       let deleteCalled = 0;
       DatastoreRequestOverride.delete = function() {
@@ -362,9 +364,9 @@ describe('Transaction', function() {
   describe('delete', function() {
     it('should push entities into a queue', function() {
       const keys = [
-        key('Product', 123),
-        key('Product', 234),
-        key('Product', 345),
+        key('Product123'),
+        key('Product234'),
+        key('Product345'),
       ];
 
       transaction.delete(keys);
@@ -611,9 +613,9 @@ describe('Transaction', function() {
   describe('save', function() {
     it('should push entities into a queue', function() {
       const entities = [
-        {key: key('Product', 123), data: 123},
-        {key: key('Product', 234), data: 234},
-        {key: key('Product', 345), data: 345},
+        {key: key('Product123'), data: 123},
+        {key: key('Product234'), data: 234},
+        {key: key('Product345'), data: 345},
       ];
 
       transaction.save(entities);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build",
+    "noImplicitAny": false,
+    "noImplicitThis": false
+  },
+  "include": [
+    "src/*.ts",
+    "test/*.ts",
+    "system-test/*.ts"
+  ]
+}

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "gts/tslint.json"
+}


### PR DESCRIPTION
*BREAKING CHANGE*: The import style of this library has changed to be consistent with [es modules](https://hacks.mozilla.org/2018/03/es-modules-a-cartoon-deep-dive/).

```js
const Datastore = require('@google-cloud/datastore')();
// or...
const Datastore = require('@google-cloud/datastore');
const ds = new Datastore();
```

```js
const {Datastore} = require('@google-cloud/datastore');
const ds = new Datastore();
```