### PR TITLE
Update doc comment showing structure of entity

### DIFF
--- a/samples/concepts.js
+++ b/samples/concepts.js
@@ -273,7 +273,15 @@ class Entity extends TestHelper {
     //   category: 'Personal',
     //   done: false,
     //   priority: 4,
-    //   description: 'Learn Cloud Datastore'
+    //   description: 'Learn Cloud Datastore',
+    //   [Symbol(KEY)]:
+    //    Key {
+    //      namespace: undefined,
+    //      id: '...',
+    //      kind: 'Task',
+    //      path: [Getter]
+    //    }
+    //   }
     // };
     console.log(entity);
     // [END datastore_lookup]


### PR DESCRIPTION
When a `get` is returned from datastore the schema of the entity has
been extended to include the key. The comment showing the expected
structure of the entity is being updated to include the key for
completeness.

Fixes b/119342563

- [ ] Tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
