### PR TITLE
Release @google-cloud/datastore v3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 [1]: https://www.npmjs.com/package/@google-cloud/datastore?activeTab=versions
 
+## v3.0.1
+
+01-15-2019 13:20 PST
+
+### Bug fixes
+- fix: ship the build directory ([#300](https://github.com/googleapis/nodejs-datastore/pull/300))
+
+### Internal / Testing Changes
+- build: check broken links in generated docs ([#292](https://github.com/googleapis/nodejs-datastore/pull/292))
+
 ## v3.0.0
 
 01-14-2019 20:31 PST

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/datastore",
   "description": "Cloud Datastore Client Library for Node.js",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {

--- a/samples/package.json
+++ b/samples/package.json
@@ -12,7 +12,7 @@
     "test": "mocha system-test/*.test.js --timeout=600000"
   },
   "dependencies": {
-    "@google-cloud/datastore": "^3.0.0",
+    "@google-cloud/datastore": "^3.0.1",
     "sinon": "^7.0.0",
     "yargs": "^12.0.1"
   },


### PR DESCRIPTION
This pull request was generated using releasetool.