### PR TITLE
docs(key): copy Datastore#key examples to Key ctor

### DIFF
--- a/src/entity.ts
+++ b/src/entity.ts
@@ -174,10 +174,39 @@ export namespace entity {
    * @param {string} [options.namespace] Optional namespace.
    *
    * @example
+   * <caption>Create an incomplete key with a kind value of `Company`.</caption>
    * const {Datastore} = require('@google-cloud/datastore');
    * const datastore = new Datastore();
+   * const key = datastore.key('Company');
+   *
+   * @example
+   * <caption>Create a complete key with a kind value of `Company` and id
+   * `123`.</caption> const {Datastore} = require('@google-cloud/datastore');
+   * const datastore = new Datastore();
+   * const key = datastore.key(['Company', 123]);
+   *
+   * @example
+   * <caption>If the ID integer is outside the bounds of a JavaScript Number
+   * object, create an Int.</caption> const {Datastore} =
+   * require('@google-cloud/datastore'); const datastore = new Datastore();
+   * const key = datastore.key([
+   *   'Company',
+   *   datastore.int('100000000000001234')
+   * ]);
+   *
+   * @example
+   * const {Datastore} = require('@google-cloud/datastore');
+   * const datastore = new Datastore();
+   * // Create a complete key with a kind value of `Company` and name `Google`.
+   * // Note: `id` is used for numeric identifiers and `name` is used otherwise.
+   * const key = datastore.key(['Company', 'Google']);
+   *
+   * @example
+   * <caption>Create a complete key from a provided namespace and
+   * path.</caption> const {Datastore} = require('@google-cloud/datastore');
+   * const datastore = new Datastore();
    * const key = datastore.key({
-   *   namespace: 'ns',
+   *   namespace: 'My-NS',
    *   path: ['Company', 123]
    * });
    */


### PR DESCRIPTION
Fixes #295

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

---

It seems like the natural way to see `Key` creation examples is to go to the API docs and click on the `Key` constructor. The `Datastore#key` method is kind of buried and contains more complete examples. This is just a copypasta from the method to the constructor.