### PR TITLE
fix: make an explicit dependency on long

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "prepare": "npm run compile",
     "pretest": "npm run compile",
     "proto": "npm run proto:datastore",
-    "proto:datastore": "mkdir -p proto && pbjs -t static-module -w commonjs -p node_modules/google-proto-files google/datastore/v1/datastore.proto | pbts -o proto/datastore.d.ts -",
+    "proto:datastore": "mkdir -p proto && pbjs -t static-module -w commonjs -p node_modules/google-proto-files google/datastore/v1/datastore.proto | pbts -i long -o proto/datastore.d.ts -",
     "docs-test": "linkinator docs -r --skip www.googleapis.com",
     "predocs-test": "npm run docs"
   },

--- a/proto/datastore.d.ts
+++ b/proto/datastore.d.ts
@@ -1,4 +1,5 @@
 import * as $protobuf from "protobufjs";
+import * as long from "long";
 /** Namespace google. */
 export namespace google {
 


### PR DESCRIPTION
I learned something today!  The `-i` flag on `pbts` will let you specific which imports to explicitly bring in.  Not sure why I need to do this, but 🤷‍♂️   Fixes #345. 