### PR TITLE
fix(docs): move ts overloads above doc string

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -615,6 +615,10 @@ class Datastore extends DatastoreRequest {
   static NO_MORE_RESULTS = 'NO_MORE_RESULTS';
   NO_MORE_RESULTS = Datastore.NO_MORE_RESULTS;
 
+  createQuery(kind?: string): Query;
+  createQuery(kind?: string[]): Query;
+  createQuery(namespace: string, kind: string): Query;
+  createQuery(namespace: string, kind: string[]): Query;
   /**
    * Create a query for the specified kind. See {@link Query} for all
    * of the available methods.
@@ -631,10 +635,6 @@ class Datastore extends DatastoreRequest {
    * const datastore = new Datastore();
    * const query = datastore.createQuery('Company');
    */
-  createQuery(kind?: string): Query;
-  createQuery(kind?: string[]): Query;
-  createQuery(namespace: string, kind: string): Query;
-  createQuery(namespace: string, kind: string[]): Query;
   createQuery(namespaceOrKind?: string|string[], kind?: string|string[]):
       Query {
     let namespace = namespaceOrKind as string;
@@ -645,6 +645,9 @@ class Datastore extends DatastoreRequest {
     return new Query(this, namespace, arrify(kind));
   }
 
+  key(options: entity.KeyOptions): entity.Key;
+  key(path: PathType[]): entity.Key;
+  key(path: string): entity.Key;
   /**
    * Helper to create a Key object, scoped to the instance's namespace by
    * default.
@@ -694,9 +697,6 @@ class Datastore extends DatastoreRequest {
    *   path: ['Company', 123]
    * });
    */
-  key(options: entity.KeyOptions): entity.Key;
-  key(path: PathType[]): entity.Key;
-  key(path: string): entity.Key;
   key(options: string|entity.KeyOptions|PathType[]): entity.Key {
     options = is.object(options) ? options : {
       namespace: this.namespace,

--- a/src/query.ts
+++ b/src/query.ts
@@ -143,6 +143,8 @@ class Query {
     this.offsetVal = -1;
   }
 
+  filter(property: string, value: {}): Query;
+  filter(property: string, operator: Operator, value: {}): Query;
   /**
    * Datastore allows querying on properties. Supported comparison operators
    * are `=`, `<`, `>`, `<=`, and `>=`. "Not equal" and `IN` operators are
@@ -181,8 +183,6 @@ class Query {
    * const key = datastore.key(['Company', 'Google']);
    * const keyQuery = query.filter('__key__', key);
    */
-  filter(property: string, value: {}): Query;
-  filter(property: string, operator: Operator, value: {}): Query;
   filter(property: string, operatorOrValue: Operator, value?: {}): Query {
     let operator = operatorOrValue as Operator;
     if (arguments.length === 2) {
@@ -380,6 +380,9 @@ class Query {
     return this;
   }
 
+  run(options?: RunQueryOptions): Promise<RunQueryResponse>;
+  run(options: RunQueryOptions, callback: RunQueryCallback): void;
+  run(callback: RunQueryCallback): void;
   /**
    * Run the query.
    *
@@ -435,9 +438,6 @@ class Query {
    *   const entities = data[0];
    * });
    */
-  run(options?: RunQueryOptions): Promise<RunQueryResponse>;
-  run(options: RunQueryOptions, callback: RunQueryCallback): void;
-  run(callback: RunQueryCallback): void;
   run(optionsOrCallback?: RunQueryOptions|RunQueryCallback,
       cb?: RunQueryCallback): void|Promise<RunQueryResponse> {
     const query = this as Query;

--- a/src/request.ts
+++ b/src/request.ts
@@ -101,6 +101,11 @@ class DatastoreRequest {
     return entityObject;
   }
 
+  allocateIds(key: entity.Key, options: AllocateIdsOptions|number):
+      Promise<AllocateIdsResponse>;
+  allocateIds(
+      key: entity.Key, options: AllocateIdsOptions|number,
+      callback: AllocateIdsCallback): void;
   /**
    * Generate IDs without creating entities.
    *
@@ -173,11 +178,6 @@ class DatastoreRequest {
    *   const apiResponse = data[1];
    * });
    */
-  allocateIds(key: entity.Key, options: AllocateIdsOptions|number):
-      Promise<AllocateIdsResponse>;
-  allocateIds(
-      key: entity.Key, options: AllocateIdsOptions|number,
-      callback: AllocateIdsCallback): void;
   allocateIds(
       key: entity.Key, options: AllocateIdsOptions|number,
       callback?: AllocateIdsCallback): void|Promise<AllocateIdsResponse> {
@@ -290,6 +290,11 @@ class DatastoreRequest {
     return stream;
   }
 
+  delete(): Promise<CommitResponse>;
+  delete(keys: Entities): void;
+  delete(keys: Entities, callback: CommitCallback): void;
+  delete(keys: Entities, gaxOptions: CallOptions, callback: CommitCallback):
+      void;
   /**
    * Delete all entities identified with the specified key(s).
    *
@@ -338,11 +343,6 @@ class DatastoreRequest {
    *   const apiResponse = data[0];
    * });
    */
-  delete(): Promise<CommitResponse>;
-  delete(keys: Entities): void;
-  delete(keys: Entities, callback: CommitCallback): void;
-  delete(keys: Entities, gaxOptions: CallOptions, callback: CommitCallback):
-      void;
   delete(
       keys?: Entities, gaxOptionsOrCallback?: CallOptions|CommitCallback,
       cb?: CommitCallback): void|Promise<CommitResponse> {
@@ -374,6 +374,11 @@ class DatastoreRequest {
         callback);
   }
 
+  get(keys: Entities,
+      options?: CreateReadStreamOptions): Promise<Entity|Transform>;
+  get(keys: Entities, callback: GetCallback): void;
+  get(keys: Entities, options: CreateReadStreamOptions,
+      callback: GetCallback): void;
   /**
    * Retrieve the entities identified with the specified key(s) in the current
    * transaction. Get operations require a valid key to retrieve the
@@ -459,11 +464,6 @@ class DatastoreRequest {
    *   const entities = data[0];
    * });
    */
-  get(keys: Entities,
-      options?: CreateReadStreamOptions): Promise<Entity|Transform>;
-  get(keys: Entities, callback: GetCallback): void;
-  get(keys: Entities, options: CreateReadStreamOptions,
-      callback: GetCallback): void;
   get(keys: Entities, optionsOrCallback?: CreateReadStreamOptions|GetCallback,
       cb?: GetCallback): void|Promise<Entity|Transform> {
     const options = typeof optionsOrCallback === 'object' && optionsOrCallback ?
@@ -480,6 +480,8 @@ class DatastoreRequest {
         }));
   }
 
+  insert(entities: Entities): Promise<CommitResponse>;
+  insert(entities: Entities, callback: CallOptions): void;
   /**
    * Maps to {@link Datastore#save}, forcing the method to be `insert`.
    *
@@ -494,8 +496,6 @@ class DatastoreRequest {
    * @param {?error} callback.err An error returned while making this request
    * @param {object} callback.apiResponse The full API response.
    */
-  insert(entities: Entities): Promise<CommitResponse>;
-  insert(entities: Entities, callback: CallOptions): void;
   insert(entities: Entities, callback?: CallOptions):
       void|Promise<CommitResponse> {
     entities =
@@ -507,6 +507,10 @@ class DatastoreRequest {
     this.save(entities, callback);
   }
 
+  runQuery(query: Query, options?: RunQueryOptions): Promise<RunQueryResponse>;
+  runQuery(query: Query, options: RunQueryOptions, callback: RunQueryCallback):
+      void;
+  runQuery(query: Query, callback: RunQueryCallback): void;
   /**
    * Datastore allows you to query entities by kind, filter them by property
    * filters, and sort them by a property name. Projection and pagination are
@@ -599,10 +603,6 @@ class DatastoreRequest {
    *   const entities = data[0];
    * });
    */
-  runQuery(query: Query, options?: RunQueryOptions): Promise<RunQueryResponse>;
-  runQuery(query: Query, options: RunQueryOptions, callback: RunQueryCallback):
-      void;
-  runQuery(query: Query, callback: RunQueryCallback): void;
   runQuery(
       query: Query, optionsOrCallback?: RunQueryOptions|RunQueryCallback,
       cb?: RunQueryCallback): void|Promise<RunQueryResponse> {
@@ -739,6 +739,11 @@ class DatastoreRequest {
     return stream;
   }
 
+  save(entities: Entities): Promise<CommitResponse>;
+  save(entities: Entities, gaxOptions?: CallOptions): Promise<CommitResponse>;
+  save(entities: Entities, gaxOptions: CallOptions, callback: SaveCallback):
+      void;
+  save(entities: Entities, callback: SaveCallback): void;
   /**
    * Insert or update the specified object(s). If a key is incomplete, its
    * associated object is inserted and the original Key object is updated to
@@ -948,11 +953,6 @@ class DatastoreRequest {
    *   const apiResponse = data[0];
    * });
    */
-  save(entities: Entities): Promise<CommitResponse>;
-  save(entities: Entities, gaxOptions?: CallOptions): Promise<CommitResponse>;
-  save(entities: Entities, gaxOptions: CallOptions, callback: SaveCallback):
-      void;
-  save(entities: Entities, callback: SaveCallback): void;
   save(
       entities: Entities, gaxOptionsOrCallback?: CallOptions|SaveCallback,
       cb?: SaveCallback): void|Promise<CommitResponse> {
@@ -1069,6 +1069,8 @@ class DatastoreRequest {
         onCommit);
   }
 
+  update(entities: Entities): Promise<CommitResponse>;
+  update(entities: Entities, callback: CallOptions): void;
   /**
    * Maps to {@link Datastore#save}, forcing the method to be `update`.
    *
@@ -1083,8 +1085,6 @@ class DatastoreRequest {
    * @param {?error} callback.err An error returned while making this request
    * @param {object} callback.apiResponse The full API response.
    */
-  update(entities: Entities): Promise<CommitResponse>;
-  update(entities: Entities, callback: CallOptions): void;
   update(entities: Entities, callback?: CallOptions):
       void|Promise<CommitResponse> {
     entities =
@@ -1096,6 +1096,8 @@ class DatastoreRequest {
     this.save(entities, callback);
   }
 
+  upsert(entities: Entities): Promise<CommitResponse>;
+  upsert(entities: Entities, callback: CallOptions): void;
   /**
    * Maps to {@link Datastore#save}, forcing the method to be `upsert`.
    *
@@ -1110,8 +1112,6 @@ class DatastoreRequest {
    * @param {?error} callback.err An error returned while making this request
    * @param {object} callback.apiResponse The full API response.
    */
-  upsert(entities: Entities): Promise<CommitResponse>;
-  upsert(entities: Entities, callback: CallOptions): void;
   upsert(entities: Entities, callback?: CallOptions):
       void|Promise<CommitResponse> {
     entities =
@@ -1123,6 +1123,7 @@ class DatastoreRequest {
     this.save(entities, callback);
   }
 
+  request_(config: RequestConfig, callback: RequestCallback): void;
   /**
    * Make a request to the API endpoint. Properties to indicate a transactional
    * or non-transactional operation are added automatically.
@@ -1135,7 +1136,6 @@ class DatastoreRequest {
    *
    * @private
    */
-  request_(config: RequestConfig, callback: RequestCallback): void;
   request_(config: RequestConfig, callback?: RequestCallback): void {
     const datastore = this.datastore;
 

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -96,6 +96,9 @@ class Transaction extends DatastoreRequest {
    *      the final commit request with.
    */
 
+  commit(gaxOptions?: CallOptions): Promise<CommitResponse>;
+  commit(callback: CommitCallback): void;
+  commit(gaxOptions: CallOptions, callback: CommitCallback): void;
   /**
    * Commit the remote transaction and finalize the current transaction
    * instance.
@@ -129,9 +132,6 @@ class Transaction extends DatastoreRequest {
    *   const apiResponse = data[0];
    * });
    */
-  commit(gaxOptions?: CallOptions): Promise<CommitResponse>;
-  commit(callback: CommitCallback): void;
-  commit(gaxOptions: CallOptions, callback: CommitCallback): void;
   commit(
       gaxOptionsOrCallback?: CallOptions|CommitCallback,
       cb?: CommitCallback): void|Promise<CommitResponse> {
@@ -295,6 +295,8 @@ class Transaction extends DatastoreRequest {
     return this.datastore.createQuery.call(this, namespace, kind as string[]);
   }
 
+  delete(): Promise<CommitResponse>;
+  delete(entities: Entities): void;
   /**
    * Delete all entities identified with the specified key(s) in the current
    * transaction.
@@ -327,8 +329,6 @@ class Transaction extends DatastoreRequest {
    *   });
    * });
    */
-  delete(): Promise<CommitResponse>;
-  delete(entities: Entities): void;
   delete(entities?: Entities): void|Promise<CommitResponse> {
     arrify(entities).forEach((ent: Entity) => {
       this.modifiedEntities_.push({
@@ -341,6 +341,10 @@ class Transaction extends DatastoreRequest {
     });
   }
 
+  rollback(): void;
+  rollback(callback: RollbackCallback): void;
+  rollback(gaxOptions: CallOptions): Promise<RollbackResponse>;
+  rollback(gaxOptions: CallOptions, callback: RollbackCallback): void;
   /**
    * Reverse a transaction remotely and finalize the current transaction
    * instance.
@@ -375,10 +379,6 @@ class Transaction extends DatastoreRequest {
    *   const apiResponse = data[0];
    * });
    */
-  rollback(): void;
-  rollback(callback: RollbackCallback): void;
-  rollback(gaxOptions: CallOptions): Promise<RollbackResponse>;
-  rollback(gaxOptions: CallOptions, callback: RollbackCallback): void;
   rollback(gaxOptionsOrCallback?: CallOptions|RollbackCallback, cb?: Function):
       void|Promise<RollbackResponse> {
     const gaxOptions =
@@ -398,6 +398,9 @@ class Transaction extends DatastoreRequest {
         });
   }
 
+  run(options?: RunOptions): Promise<BeginTransactionResponse>;
+  run(callback?: RunCallback): void;
+  run(options?: RunOptions, callback?: RunCallback): void;
   /**
    * Begin a remote transaction. In the callback provided, run your
    * transactional commands.
@@ -448,9 +451,6 @@ class Transaction extends DatastoreRequest {
    *   const apiResponse = data[1];
    * });
    */
-  run(options?: RunOptions): Promise<BeginTransactionResponse>;
-  run(callback?: RunCallback): void;
-  run(options?: RunOptions, callback?: RunCallback): void;
   run(optionsOrCallback?: RunOptions|RunCallback|Entity,
       cb?: RunCallback): void|Promise<BeginTransactionResponse> {
     const options =


### PR DESCRIPTION
Fixes #348

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
