### PR TITLE
fix: assign more restrictive type to PathType (#433)

### DIFF
--- a/src/entity.ts
+++ b/src/entity.ts
@@ -18,6 +18,7 @@ import arrify = require('arrify');
 import * as extend from 'extend';
 import * as is from 'is';
 import {Query, QueryProto} from './query';
+import {PathType} from '.';
 
 // tslint:disable-next-line no-namespace
 export namespace entity {
@@ -162,7 +163,7 @@ export namespace entity {
 
   export interface KeyOptions {
     namespace?: string;
-    path: Array<string | number>;
+    path: PathType[];
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,8 +37,7 @@ import {Transaction} from './transaction';
 
 const {grpc} = new GrpcClient();
 
-// tslint:disable-next-line: no-any
-export type PathType = any;
+export type PathType = string | number | entity.Int;
 
 // Import the clients for each version supported by this package.
 const gapic = Object.freeze({
@@ -701,13 +700,13 @@ class Datastore extends DatastoreRequest {
    * });
    */
   key(options: string | entity.KeyOptions | PathType[]): entity.Key {
-    options = is.object(options)
-      ? options
+    const keyOptions = is.object(options)
+      ? (options as entity.KeyOptions)
       : {
           namespace: this.namespace,
           path: arrify(options) as PathType[],
         };
-    return new entity.Key(options as entity.KeyOptions);
+    return new entity.Key(keyOptions);
   }
 
   /**

--- a/system-test/datastore.ts
+++ b/system-test/datastore.ts
@@ -159,7 +159,7 @@ describe('Datastore', () => {
       const [entity] = await datastore.get(postKey);
       delete entity[datastore.KEY];
       assert.deepStrictEqual(entity, data);
-      await datastore.delete(datastore.key(['Post', assignedId]));
+      await datastore.delete(datastore.key(['Post', assignedId as string]));
     });
 
     it('should save/get/delete with a generated key id', async () => {


### PR DESCRIPTION
This prevents `Key path element must not be incomplete` runtime error, and also allows using big int
(datastore.Int) when creating a key using KeyOptions object as an argument.

Fixes #433 (it's a good idea to open an issue first for discussion)

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
