### PR TITLE
fix: add `parseInt` to constructor of task keys

### DIFF
--- a/samples/tasks.js
+++ b/samples/tasks.js
@@ -100,7 +100,7 @@ async function addTask(description) {
 // [START datastore_update_entity]
 async function markDone(taskId) {
   const transaction = datastore.transaction();
-  const taskKey = datastore.key(['Task', parseInt(taskId)]);
+  const taskKey = datastore.key(['Task', datastore.int(taskId)]);
 
   try {
     await transaction.run();
@@ -133,7 +133,7 @@ async function listTasks() {
 
 // [START datastore_delete_entity]
 async function deleteTask(taskId) {
-  const taskKey = datastore.key(['Task', parseInt(taskId)]);
+  const taskKey = datastore.key(['Task', datastore.int(taskId)]);
 
   await datastore.delete(taskKey);
   console.log(`Task ${taskId} deleted successfully.`);

--- a/samples/tasks.js
+++ b/samples/tasks.js
@@ -100,7 +100,7 @@ async function addTask(description) {
 // [START datastore_update_entity]
 async function markDone(taskId) {
   const transaction = datastore.transaction();
-  const taskKey = datastore.key(['Task', taskId]);
+  const taskKey = datastore.key(['Task', parseInt(taskId)]);
 
   try {
     await transaction.run();
@@ -133,7 +133,7 @@ async function listTasks() {
 
 // [START datastore_delete_entity]
 async function deleteTask(taskId) {
-  const taskKey = datastore.key(['Task', taskId]);
+  const taskKey = datastore.key(['Task', parseInt(taskId)]);
 
   await datastore.delete(taskKey);
   console.log(`Task ${taskId} deleted successfully.`);


### PR DESCRIPTION
The `id` property of `Key` is a string, update the use site of the key
to parse it as an int when being used to create a key.

