### PR TITLE
feat: support key re-use from serialized path

### DIFF
--- a/src/entity.ts
+++ b/src/entity.ts
@@ -223,8 +223,7 @@ export namespace entity {
    *   path: ['Company', 123]
    * });
    *
-   * @example
-   * <caption>Serialize the key for later re-use.</caption>
+   * @example <caption>Serialize the key for later re-use.</caption>
    * const {Datastore} = require('@google-cloud/datastore');
    * const datastore = new Datastore();
    * const key = datastore.key({

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -300,7 +300,9 @@ export namespace entity {
           };
 
           if (this.parent) {
-            serializedKey.path = this.parent.serialized.path.concat(serializedKey.path);
+            serializedKey.path = this.parent.serialized.path.concat(
+              serializedKey.path
+            );
           }
 
           return serializedKey;

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -224,9 +224,7 @@ export namespace entity {
    * });
    *
    * @example
-   * //-
-   * // Serialize the key for later re-use.
-   * //-
+   * <caption>Serialize the key for later re-use.</caption>
    * const {Datastore} = require('@google-cloud/datastore');
    * const datastore = new Datastore();
    * const key = datastore.key({
@@ -243,7 +241,6 @@ export namespace entity {
     kind: string;
     parent?: Key;
     path!: Array<string | number>;
-    serialized!: object;
 
     constructor(options: KeyOptions) {
       /**
@@ -285,29 +282,36 @@ export namespace entity {
           ]);
         },
       });
+    }
 
-      // `serialized` is computed on demand to consider any changes that may
-      // have been made to the key.
-      /**
-       * @name Key#serialized
-       * @type {array}
-       */
-      Object.defineProperty(this, 'serialized', {
-        get() {
-          const serializedKey = {
-            namespace: this.namespace,
-            path: [this.kind, this.name || new Int(this.id)],
-          };
+    /**
+     * Access the `serialized` property for a library-compatible way to re-use a
+     * key.
+     *
+     * @returns {object}
+     *
+     * @example
+     * const key = datastore.key({
+     *   namespace: 'My-NS',
+     *   path: ['Company', 123]
+     * });
+     *
+     * // Later...
+     * const key = datastore.key(key.serialized);
+     */
+    get serialized() {
+      const serializedKey = {
+        namespace: this.namespace,
+        path: [this.kind, this.name || new Int(this.id!)],
+      };
 
-          if (this.parent) {
-            serializedKey.path = this.parent.serialized.path.concat(
-              serializedKey.path
-            );
-          }
+      if (this.parent) {
+        serializedKey.path = this.parent.serialized.path.concat(
+          serializedKey.path
+        );
+      }
 
-          return serializedKey;
-        },
-      });
+      return serializedKey;
     }
   }
 

--- a/test/entity.ts
+++ b/test/entity.ts
@@ -167,12 +167,16 @@ describe('entity', () => {
         namespace: 'namespace',
         path: ['ParentKind', 'name', 'Kind', 1, 'SubKind', new entity.Int('1')],
       });
-      assert.deepStrictEqual(key.serialized,
-        {
-          namespace: 'namespace',
-          path: [
-            'ParentKind', 'name', 'Kind', new entity.Int(1).valueOf(), 'SubKind', new entity.Int('1').valueOf()
-          ],
+      assert.deepStrictEqual(key.serialized, {
+        namespace: 'namespace',
+        path: [
+          'ParentKind',
+          'name',
+          'Kind',
+          new entity.Int(1).valueOf(),
+          'SubKind',
+          new entity.Int('1').valueOf(),
+        ],
       });
     });
 

--- a/test/entity.ts
+++ b/test/entity.ts
@@ -161,6 +161,28 @@ describe('entity', () => {
 
       assert.deepStrictEqual(key.path, ['GrandParentKind', 1, 'ParentKind', 1]);
     });
+
+    it('should always compute the correct serialized path', () => {
+      const key = new entity.Key({
+        namespace: 'namespace',
+        path: ['ParentKind', 'name', 'Kind', 1, 'SubKind', new entity.Int('1')],
+      });
+      assert.deepStrictEqual(key.serialized,
+        {
+          namespace: 'namespace',
+          path: [
+            'ParentKind', 'name', 'Kind', new entity.Int(1).valueOf(), 'SubKind', new entity.Int('1').valueOf()
+          ],
+      });
+    });
+
+    it('should allow re-creating a Key from the serialized path', () => {
+      const key = new entity.Key({
+        path: ['ParentKind', 'name', 'Kind', 1, 'SubKind', new entity.Int('1')],
+      });
+      const key2 = new entity.Key(key.serialized);
+      assert.deepStrictEqual(key.serialized, key2.serialized);
+    });
   });
 
   describe('isDsKey', () => {


### PR DESCRIPTION
Fixes #59 

This exposes a `serialized` property on a Key object. It will correctly differentiate between a key name and id, so that you can re-create a key with it:

```js
const key = datastore.key({
  namespace: 'My-NS',
  path: ['Company', 123]
);
// Later...
const key = datastore.key(key.serialized);
```