### PR TITLE
feat: support DSInt / DSDouble recognition from JSON

### DIFF
--- a/src/entity.ts
+++ b/src/entity.ts
@@ -63,8 +63,14 @@ export namespace entity {
    * const aDouble = datastore.double(7.3);
    */
   export class Double {
+    type: string;
     value: number;
     constructor(value: number) {
+      /**
+       * @name Double#type
+       * @type {string}
+       */
+      this.type = 'DatastoreDouble';
       /**
        * @name Double#value
        * @type {number}
@@ -85,6 +91,23 @@ export namespace entity {
   }
 
   /**
+   * Check if a value is a Datastore Double object converted from JSON.
+   *
+   * @private
+   * @param {*} value
+   * @returns {boolean}
+   */
+  export function isDsDoubleLike(value: unknown) {
+    const maybeDsDouble = value as Double;
+    return (
+      isDsDouble(maybeDsDouble) ||
+      (is.object(maybeDsDouble) &&
+        is.number(maybeDsDouble.value) &&
+        maybeDsDouble.type === 'DatastoreDouble')
+    );
+  }
+
+  /**
    * Build a Datastore Int object. For long integers, a string can be provided.
    *
    * @class
@@ -96,8 +119,14 @@ export namespace entity {
    * const anInt = datastore.int(7);
    */
   export class Int {
+    type: string;
     value: string;
     constructor(value: number | string) {
+      /**
+       * @name Int#type
+       * @type {string}
+       */
+      this.type = 'DatastoreInt';
       /**
        * @name Int#value
        * @type {string}
@@ -118,14 +147,20 @@ export namespace entity {
   }
 
   /**
-   * Check if something is a Datastore Int object converted from JSON.
+   * Check if a value is a Datastore Int object converted from JSON.
    *
    * @private
    * @param {*} value
    * @returns {boolean}
    */
-  export function isJsonDsInt(value?: {}) {
-    return value && typeof value === "object" && value.hasOwnProperty("value");
+  export function isDsIntLike(value: unknown) {
+    const maybeDsInt = value as Int;
+    return (
+      isDsInt(maybeDsInt) ||
+      (is.object(maybeDsInt) &&
+        is.string(maybeDsInt.value) &&
+        maybeDsInt.type === 'DatastoreInt')
+    );
   }
 
   export interface Coordinates {
@@ -266,7 +301,11 @@ export namespace entity {
       if (options.path.length % 2 === 0) {
         const identifier = options.path.pop();
 
-        if (is.number(identifier) || isDsInt(identifier) || isJsonDsInt(identifier)) {
+        if (
+          is.number(identifier) ||
+          isDsInt(identifier) ||
+          isDsIntLike(identifier)
+        ) {
           this.id = (((identifier as {}) as Int).value || identifier) as string;
         } else if (is.string(identifier)) {
           this.name = identifier as string;

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -117,6 +117,17 @@ export namespace entity {
     return value instanceof entity.Int;
   }
 
+  /**
+   * Check if something is a Datastore Int object converted from JSON.
+   *
+   * @private
+   * @param {*} value
+   * @returns {boolean}
+   */
+  export function isJsonDsInt(value?: {}) {
+    return value && typeof value === "object" && value.hasOwnProperty("value");
+  }
+
   export interface Coordinates {
     latitude: number;
     longitude: number;
@@ -255,7 +266,7 @@ export namespace entity {
       if (options.path.length % 2 === 0) {
         const identifier = options.path.pop();
 
-        if (is.number(identifier) || isDsInt(identifier)) {
+        if (is.number(identifier) || isDsInt(identifier) || isJsonDsInt(identifier)) {
           this.id = (((identifier as {}) as Int).value || identifier) as string;
         } else if (is.string(identifier)) {
           this.name = identifier as string;

--- a/test/entity.ts
+++ b/test/entity.ts
@@ -187,6 +187,15 @@ describe('entity', () => {
       const key2 = new entity.Key(key.serialized);
       assert.deepStrictEqual(key.serialized, key2.serialized);
     });
+
+    it('should allow re-creating a Key from the JSON serialized path', () => {
+      const key = new entity.Key({
+        path: ['ParentKind', 'name', 'Kind', 1, 'SubKind', new entity.Int('1')],
+      });
+      const jsonRoundtrip = (v: object) => JSON.parse(JSON.stringify(v));
+      const key2 = new entity.Key(jsonRoundtrip(key.serialized));
+      assert.deepStrictEqual(key.serialized, key2.serialized);
+    });
   });
 
   describe('isDsKey', () => {

--- a/test/entity.ts
+++ b/test/entity.ts
@@ -59,6 +59,19 @@ describe('entity', () => {
     });
   });
 
+  describe('isDsDoubleLike', () => {
+    it('should correctly identify a Double', () => {
+      const double = new entity.Double(0.42);
+      assert.strictEqual(entity.isDsDoubleLike(double), true);
+    });
+
+    it('should correctly identify a POJO Double', () => {
+      const double = new entity.Double(0.42);
+      const pojoDouble = JSON.parse(JSON.stringify(double));
+      assert.strictEqual(entity.isDsDoubleLike(pojoDouble), true);
+    });
+  });
+
   describe('Int', () => {
     it('should store the stringified value', () => {
       const value = 8;
@@ -82,6 +95,19 @@ describe('entity', () => {
     it('should correctly identify a primitive', () => {
       const primitiveInt = 42;
       assert.strictEqual(entity.isDsInt(primitiveInt), false);
+    });
+  });
+
+  describe('isDsIntLike', () => {
+    it('should correctly identify an Int', () => {
+      const int = new entity.Int(42);
+      assert.strictEqual(entity.isDsIntLike(int), true);
+    });
+
+    it('should correctly identify a POJO Int', () => {
+      const int = new entity.Int(42);
+      const pojoInt = JSON.parse(JSON.stringify(int));
+      assert.strictEqual(entity.isDsIntLike(pojoInt), true);
     });
   });
 
@@ -192,8 +218,8 @@ describe('entity', () => {
       const key = new entity.Key({
         path: ['ParentKind', 'name', 'Kind', 1, 'SubKind', new entity.Int('1')],
       });
-      const jsonRoundtrip = (v: object) => JSON.parse(JSON.stringify(v));
-      const key2 = new entity.Key(jsonRoundtrip(key.serialized));
+      const toPOJO = (v: object) => JSON.parse(JSON.stringify(v));
+      const key2 = new entity.Key(toPOJO(key.serialized));
       assert.deepStrictEqual(key.serialized, key2.serialized);
     });
   });


### PR DESCRIPTION
We had issues comparable to #59 in the past. IMO the proposed solution in #474 is only half of the solution: the missing part is more forgiving deserialisation. Note also that users like @beaulac [have reported](https://github.com/googleapis/nodejs-datastore/issues/59#issuecomment-366739401) creating work-arounds for this specifically. This PR solves this by extending the constructor of Key.

Fixes #59. Serialization comes with deserialization, and the current
deserialization did not deal well with plain JavaScript objects like
those returned from JSON deserialization.

Given this implementation is it easy & safe to transfers Keys over
networks and other non-JavaScript interfaces.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)