### PR TITLE
fix: transaction#run overloads' params types correction

### DIFF
--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -445,8 +445,8 @@ class Transaction extends DatastoreRequest {
   }
 
   run(options?: RunOptions): Promise<RunResponse>;
-  run(callback?: RunCallback): void;
-  run(options?: RunOptions, callback?: RunCallback): void;
+  run(callback: RunCallback): void;
+  run(options: RunOptions, callback: RunCallback): void;
   /**
    * Begin a remote transaction. In the callback provided, run your
    * transactional commands.


### PR DESCRIPTION
- [x] Tests and linter pass
