### PR TITLE
fix: upgrade and pin to @grpc/grpc-js@0.6.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@google-cloud/projectify": "^1.0.0",
     "@google-cloud/promisify": "^1.0.0",
-    "@grpc/grpc-js": "^0.6.0",
+    "@grpc/grpc-js": "0.6.9",
     "@types/duplexify": "^3.6.0",
     "@types/long": "^4.0.0",
     "arrify": "^2.0.1",


### PR DESCRIPTION
This explicitly upgrades us to `@grpc/grpc-js@0.6.9`, and pins us there, addressing an internal p1 customer issue we are seeing.

We should eventually look at removing this dependency, given that it's already pulled in by `google-gax`, perhaps we could have `google-gax` export the types being used by datastore:

```
import {ChannelCredentials} from '@grpc/grpc-js';
```