### PR TITLE
feat: add async getProjectId method

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "test": "c8 mocha build/test"
   },
   "dependencies": {
-    "@google-cloud/projectify": "^2.0.0",
     "@google-cloud/promisify": "^2.0.0",
     "arrify": "^2.0.1",
     "concat-stream": "^2.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -381,7 +381,6 @@ const urlSafeKey = new entity.URLSafeKey();
 class Datastore extends DatastoreRequest {
   clients_: Map<string, ClientStub>;
   namespace?: string;
-  projectId: string;
   defaultBaseUrl_: string;
   options: DatastoreOptions;
   baseUrl_?: string;
@@ -400,15 +399,7 @@ class Datastore extends DatastoreRequest {
      */
     this.namespace = options.namespace;
 
-    const userProvidedProjectId =
-      options.projectId || process.env.DATASTORE_PROJECT_ID;
-    const defaultProjectId = '{{projectId}}';
-
-    /**
-     * @name Datastore#projectId
-     * @type {string}
-     */
-    this.projectId = userProvidedProjectId || defaultProjectId;
+    options.projectId = options.projectId || process.env.DATASTORE_PROJECT_ID;
 
     this.defaultBaseUrl_ = 'datastore.googleapis.com';
     this.determineBaseUrl_(options.apiEndpoint);
@@ -420,7 +411,6 @@ class Datastore extends DatastoreRequest {
         scopes: gapic.v1.DatastoreClient.scopes,
         servicePath: this.baseUrl_,
         port: typeof this.port_ === 'number' ? this.port_ : 443,
-        projectId: userProvidedProjectId,
       },
       options
     );
@@ -429,6 +419,10 @@ class Datastore extends DatastoreRequest {
     }
 
     this.auth = new GoogleAuth(this.options);
+  }
+
+  getProjectId(): Promise<string> {
+    return this.auth.getProjectId();
   }
 
   /**

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -49,7 +49,6 @@ import {
  * const transaction = datastore.transaction();
  */
 class Transaction extends DatastoreRequest {
-  projectId: string;
   namespace?: string;
   readOnly: boolean;
   request: Function;
@@ -63,11 +62,6 @@ class Transaction extends DatastoreRequest {
      */
     this.datastore = datastore;
 
-    /**
-     * @name Transaction#projectId
-     * @type {string}
-     */
-    this.projectId = datastore.projectId;
     /**
      * @name Transaction#namespace
      * @type {string}

--- a/test/index.ts
+++ b/test/index.ts
@@ -190,13 +190,7 @@ describe('Datastore', () => {
     });
 
     it('should localize the projectId', () => {
-      assert.strictEqual(datastore.projectId, PROJECT_ID);
       assert.strictEqual(datastore.options.projectId, PROJECT_ID);
-    });
-
-    it('should default project ID to placeholder', () => {
-      const datastore = new Datastore({});
-      assert.strictEqual(datastore.projectId, '{{projectId}}');
     });
 
     it('should not default options.projectId to placeholder', () => {
@@ -206,12 +200,8 @@ describe('Datastore', () => {
 
     it('should use DATASTORE_PROJECT_ID', () => {
       const projectId = 'overridden-project-id';
-
       process.env.DATASTORE_PROJECT_ID = projectId;
-
       const datastore = new Datastore({});
-
-      assert.strictEqual(datastore.projectId, projectId);
       assert.strictEqual(datastore.options.projectId, projectId);
     });
 

--- a/test/transaction.ts
+++ b/test/transaction.ts
@@ -100,10 +100,6 @@ describe('Transaction', () => {
       assert.strictEqual(transaction.datastore, DATASTORE);
     });
 
-    it('should localize the project ID', () => {
-      assert.strictEqual(transaction.projectId, PROJECT_ID);
-    });
-
     it('should localize the namespace', () => {
       assert.strictEqual(transaction.namespace, NAMESPACE);
     });


### PR DESCRIPTION
BREAKING CHANGE: The `Datastore.projectId` property has been removed, and replaced with an asynchronous `getProjectid()` method.  The projectId cannot be determined synchronously, so the previous approach was to use a `{{projectId}}` string placeholder if the projectId had not yet been acquired.  This made it difficult to know exactly when the property would be defined.  

As an added bonus, the `@google-cloud/projectify` dependency has been removed. Adding @crwilcox because this would be a breaking change (we're about to ship one).