### PR TITLE
docs: direct to documentation for datastore, not the product landing page

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "datastore",
   "name_pretty": "Google Cloud Datastore",
-  "product_documentation": "https://cloud.google.com/datastore",
+  "product_documentation": "https://cloud.google.com/datastore/docs",
   "client_documentation": "https://googleapis.dev/nodejs/datastore/latest",
   "issue_tracker": "https://issuetracker.google.com/savedsearches/559768",
   "release_level": "ga",

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Apache Version 2.0
 See [LICENSE](https://github.com/googleapis/nodejs-datastore/blob/master/LICENSE)
 
 [client-docs]: https://googleapis.dev/nodejs/datastore/latest
-[product-docs]: https://cloud.google.com/datastore
+[product-docs]: https://cloud.google.com/datastore/docs
 [shell_img]: https://gstatic.com/cloudssh/images/open-btn.png
 [projects]: https://console.cloud.google.com/project
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing


### PR DESCRIPTION
Towards #729