### PR TITLE
test: fix flaky projection query test

### DIFF
--- a/samples/concepts.js
+++ b/samples/concepts.js
@@ -39,10 +39,12 @@ let datastore = {
   save: makeStub(),
 };
 
+const namespace = `${Date.now()}`;
 class TestHelper {
   constructor(projectId) {
     const options = {
       projectId: projectId,
+      namespace,
     };
     this.datastore = new Datastore(options);
   }
@@ -53,6 +55,7 @@ class Entity extends TestHelper {
     super(projectId);
     // To create the keys, we have to use this instance of Datastore.
     datastore.key = this.datastore.key;
+    datastore.namespace = this.datastore.namespace;
 
     this.incompleteKey = this.getIncompleteKey();
     this.namedKey = this.getNamedKey();

--- a/samples/test/concepts.test.js
+++ b/samples/test/concepts.test.js
@@ -43,9 +43,19 @@ describe('concepts', () => {
 
   after(async () => {
     const datastore = transaction.datastore;
-    const query = datastore.createQuery('Task').select('__key__');
+    const query = datastore.createQuery('__kind__').select('__key__');
     const [entities] = await datastore.runQuery(query);
-    await datastore.delete(entities.map(entity => entity[datastore.KEY]));
+    const testKinds = entities.map(entity => entity[datastore.KEY].name);
+
+    async function deleteEntities(kind) {
+      const query = datastore.createQuery(kind).select('__key__');
+      const [entities] = await datastore.runQuery(query);
+      const keys = entities.map(entity => {
+        return entity[datastore.KEY];
+      });
+      await datastore.delete(keys);
+    }
+    await Promise.all(testKinds.map(kind => deleteEntities(kind)));
   });
 
   // Transactions


### PR DESCRIPTION
In sample test everything is running on `Task` kind with `default` namespace.
During concurrent build run projection query was fail.
Added namespace on Query and making sure that all the entities are deleting on sample test.
Fixes #640
