### PR TITLE
feat: introduce import/export + Index class

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "sinon": "^9.0.1",
     "ts-loader": "^8.0.0",
     "typescript": "^3.8.3",
-    "uuid": "^8.3.0",
     "webpack": "^4.42.0",
     "webpack-cli": "^3.3.11"
   },

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "linkinator": "^2.0.3",
     "mocha": "^8.0.0",
     "null-loader": "^4.0.0",
+    "p-queue": "^6.6.1",
     "pack-n-play": "^1.0.0-2",
     "proxyquire": "^2.1.3",
     "sinon": "^9.0.1",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@microsoft/api-extractor": "^7.8.10",
     "@types/extend": "^3.0.1",
     "@types/is": "0.0.21",
+    "@types/js-yaml": "^3.12.5",
     "@types/mocha": "^8.0.0",
     "@types/node": "^13.9.0",
     "@types/proxyquire": "^1.3.28",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "clean": "gts clean",
-    "compile": "tsc -p . && cp -r proto* build/",
+    "compile": "tsc -p . && cp -r proto* build/ && cp -r system-test/data build/system-test",
     "compile-protos": "compileProtos src",
     "docs": "jsdoc -c .jsdoc.js",
     "predocs-test": "npm run docs",
@@ -49,19 +49,25 @@
     "extend": "^3.0.2",
     "google-gax": "^2.2.0",
     "is": "^3.3.0",
+    "pumpify": "^2.0.1",
     "split-array-stream": "^2.0.0",
     "stream-events": "^1.0.5"
   },
   "devDependencies": {
+    "@google-cloud/storage": "^5.3.0",
+    "@microsoft/api-documenter": "^7.8.10",
+    "@microsoft/api-extractor": "^7.8.10",
     "@types/extend": "^3.0.1",
     "@types/is": "0.0.21",
     "@types/mocha": "^8.0.0",
     "@types/node": "^13.9.0",
     "@types/proxyquire": "^1.3.28",
+    "@types/pumpify": "^1.4.1",
     "@types/sinon": "^9.0.0",
     "c8": "^7.1.0",
     "codecov": "^3.6.5",
     "gts": "^2.0.0",
+    "js-yaml": "^3.14.0",
     "jsdoc": "^3.6.3",
     "jsdoc-fresh": "^1.0.2",
     "jsdoc-region-tag": "^1.0.4",
@@ -73,10 +79,9 @@
     "sinon": "^9.0.1",
     "ts-loader": "^8.0.0",
     "typescript": "^3.8.3",
+    "uuid": "^8.3.0",
     "webpack": "^4.42.0",
-    "webpack-cli": "^3.3.11",
-    "@microsoft/api-documenter": "^7.8.10",
-    "@microsoft/api-extractor": "^7.8.10"
+    "webpack-cli": "^3.3.11"
   },
   "engines": {
     "node": ">=10"

--- a/samples/export.js
+++ b/samples/export.js
@@ -1,0 +1,48 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+async function main(bucket = 'YOUR_BUCKET_NAME') {
+  // [START datastore_admin_entities_export]
+  const {Datastore} = require('@google-cloud/datastore');
+  const datastore = new Datastore();
+
+  async function exportEntities() {
+    /**
+     * TODO(developer): Uncomment these variables before running the sample.
+     */
+    // const bucket = 'YOUR_BUCKET_NAME';
+
+    const [exportOperation] = await datastore.export({bucket});
+    await exportOperation.promise();
+
+    // The export operation has created a new file in your bucket, e.g.
+    // gs://{YOUR_BUCKET_NAME}/{timestamp}/{timestamp}.overall_export.metadata
+    console.log(`Export file created: ${exportOperation.result.outputUrl}`);
+
+    // You may also choose to include only specific kinds and namespaces.
+    const [specificExportOperation] = await datastore.export({
+      bucket,
+      kinds: ['Employee', 'Task'],
+      namespaces: ['Company'],
+    });
+    await specificExportOperation.promise();
+    console.log(specificExportOperation.result.outputUrl);
+  }
+
+  await exportEntities();
+  // [END datastore_admin_entities_export]
+}
+
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/samples/import.js
+++ b/samples/import.js
@@ -1,0 +1,53 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+async function main(file = 'YOUR_FILE_NAME') {
+  // [START datastore_admin_entities_import]
+  const {Datastore} = require('@google-cloud/datastore');
+  const datastore = new Datastore();
+
+  async function importEntities() {
+    /**
+     * TODO(developer): Uncomment these variables before running the sample.
+     */
+    // const file = 'YOUR_FILE_NAME';
+
+    const [importOperation] = await datastore.import({file});
+
+    // Uncomment to await the results of the operation.
+    // await importOperation.promise();
+
+    // Or cancel the operation.
+    await importOperation.cancel();
+
+    // You may also choose to include only specific kinds and namespaces.
+    const [specificImportOperation] = await datastore.import({
+      file,
+      kinds: ['Employee', 'Task'],
+      namespaces: ['Company'],
+    });
+
+    // Uncomment to await the results of the operation.
+    // await specificImportOperation.promise();
+
+    // Or cancel the operation.
+    await specificImportOperation.cancel();
+  }
+
+  await importEntities();
+  // [END datastore_admin_entities_import]
+}
+
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/samples/indexes.get.js
+++ b/samples/indexes.get.js
@@ -1,0 +1,39 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+async function main(indexId = 'YOUR_INDEX_ID') {
+  // [START datastore_admin_index_get]
+  const {Datastore} = require('@google-cloud/datastore');
+  const datastore = new Datastore();
+
+  async function getIndex() {
+    /**
+     * TODO(developer): Uncomment these variables before running the sample.
+     */
+    // const indexId = 'YOUR_INDEX_ID';
+
+    // Create a reference to the index before performing operations on it.
+    const index = datastore.index(indexId);
+
+    // Get the index's metadata, including its state, properties, and more.
+    const [metadata] = await index.getMetadata();
+    console.log('Properties:', metadata.properties);
+  }
+
+  await getIndex();
+  // [END datastore_admin_index_get]
+}
+
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/samples/indexes.list.js
+++ b/samples/indexes.list.js
@@ -1,0 +1,35 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+async function main() {
+  // [START datastore_admin_index_list]
+  const {Datastore} = require('@google-cloud/datastore');
+  const datastore = new Datastore();
+
+  async function listIndexes() {
+    const [indexes] = await datastore.getIndexes();
+
+    console.log(`${indexes.length} indexes returned.`);
+
+    // Each returned Index object includes metadata about the index.
+    const [firstIndex] = indexes;
+    console.log('Properties:', firstIndex.metadata.properties);
+  }
+
+  await listIndexes();
+  // [END datastore_admin_index_list]
+}
+
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/samples/indexes.list.js
+++ b/samples/indexes.list.js
@@ -25,6 +25,16 @@ async function main() {
     // Each returned Index object includes metadata about the index.
     const [firstIndex] = indexes;
     console.log('Properties:', firstIndex.metadata.properties);
+
+    // You may also get Index references as a readable object stream.
+    datastore
+      .getIndexesStream()
+      .on('data', index => {
+        console.log('Properties:', index.metadata.properties);
+      })
+      .on('end', () => {
+        // All matching Index objects have been returned.
+      });
   }
 
   await listIndexes();

--- a/samples/package.json
+++ b/samples/package.json
@@ -18,9 +18,7 @@
     "sinon": "^9.0.0"
   },
   "devDependencies": {
-    "@google-cloud/storage": "^5.3.0",
     "chai": "^4.2.0",
-    "mocha": "^8.0.0",
-    "p-queue": "^6.6.1"
+    "mocha": "^8.0.0"
   }
 }

--- a/samples/package.json
+++ b/samples/package.json
@@ -18,7 +18,9 @@
     "sinon": "^9.0.0"
   },
   "devDependencies": {
+    "@google-cloud/storage": "^5.3.0",
     "chai": "^4.2.0",
-    "mocha": "^8.0.0"
+    "mocha": "^8.0.0",
+    "p-queue": "^6.6.1"
   }
 }

--- a/samples/test/import-export.test.js
+++ b/samples/test/import-export.test.js
@@ -1,0 +1,70 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const {Datastore} = require('@google-cloud/datastore');
+const {Storage} = require('@google-cloud/storage');
+const {assert} = require('chai');
+const cp = require('child_process');
+const {before, describe, it} = require('mocha');
+const {default: Q} = require('p-queue');
+
+const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
+
+describe('import/export entities', async () => {
+  const datastore = new Datastore();
+
+  const gcs = new Storage();
+  const BUCKET_ID = 'nodejs-datastore-system-tests';
+  const BUCKET = gcs.bucket(BUCKET_ID);
+  let EXPORTED_FILE;
+
+  before(async () => {
+    // Remove stale exported entities.
+    const q = new Q({concurrency: 5});
+    const [files] = await BUCKET.getFiles();
+    await Promise.all(
+      files.filter(file => {
+        const oneHourAgo = new Date(Date.now() - 3600000);
+        const shouldDelete = file.metadata.timeCreated <= oneHourAgo;
+        if (shouldDelete) {
+          q.add(async () => {
+            try {
+              await file.delete();
+            } catch (e) {
+              console.log(`Error deleting file: ${file.name}`);
+            }
+          });
+        }
+        return shouldDelete;
+      })
+    );
+
+    const [exportOperation] = await datastore.export({
+      bucket: BUCKET_ID,
+    });
+    await exportOperation.promise();
+    EXPORTED_FILE = exportOperation.result.outputUrl;
+  });
+
+  it('should export entities', async () => {
+    const stdout = execSync(`node ./export.js ${BUCKET_ID}`);
+    assert.include(stdout, 'Export file created:');
+  });
+
+  it('should import entities', () => {
+    execSync(`node ./import.js ${EXPORTED_FILE}`);
+  });
+});

--- a/samples/test/import-export.test.js
+++ b/samples/test/import-export.test.js
@@ -15,43 +15,19 @@
 'use strict';
 
 const {Datastore} = require('@google-cloud/datastore');
-const {Storage} = require('@google-cloud/storage');
 const {assert} = require('chai');
 const cp = require('child_process');
 const {before, describe, it} = require('mocha');
-const {default: Q} = require('p-queue');
 
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
 describe('import/export entities', async () => {
   const datastore = new Datastore();
 
-  const gcs = new Storage();
   const BUCKET_ID = 'nodejs-datastore-system-tests';
-  const BUCKET = gcs.bucket(BUCKET_ID);
   let EXPORTED_FILE;
 
   before(async () => {
-    // Remove stale exported entities.
-    const q = new Q({concurrency: 5});
-    const [files] = await BUCKET.getFiles();
-    await Promise.all(
-      files.filter(file => {
-        const oneHourAgo = new Date(Date.now() - 3600000);
-        const shouldDelete = file.metadata.timeCreated <= oneHourAgo;
-        if (shouldDelete) {
-          q.add(async () => {
-            try {
-              await file.delete();
-            } catch (e) {
-              console.log(`Error deleting file: ${file.name}`);
-            }
-          });
-        }
-        return shouldDelete;
-      })
-    );
-
     const [exportOperation] = await datastore.export({
       bucket: BUCKET_ID,
     });

--- a/samples/test/indexes.test.js
+++ b/samples/test/indexes.test.js
@@ -1,0 +1,41 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const {Datastore} = require('@google-cloud/datastore');
+const {assert} = require('chai');
+const cp = require('child_process');
+const {describe, it} = require('mocha');
+
+const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
+
+describe('indexes', async () => {
+  const datastore = new Datastore();
+
+  // @TODO: Until the protos support creating indexes, these tests depend on
+  // the remote state of declared indexes. Could be flaky!
+
+  it('should list indexes', async () => {
+    const [indexes] = await datastore.getIndexes();
+    const stdout = execSync('node ./indexes.list.js');
+    assert.include(stdout, `${indexes.length} indexes returned.`);
+  });
+
+  it('should get a specific index', async () => {
+    const [indexes] = await datastore.getIndexes();
+    const stdout = execSync(`node ./indexes.get.js ${indexes[0].id}`);
+    assert.include(stdout, 'Properties:');
+  });
+});

--- a/src/index-class.ts
+++ b/src/index-class.ts
@@ -59,7 +59,7 @@ export type IIndex = google.datastore.admin.v1.IIndex;
 /**
  * @class
  * @param {Datastore} datastore The parent instance of this index.
- * @param {string} name Name of the index.
+ * @param {string} id The index name or id.
  *
  * @example
  * const {Datastore} = require('@google-cloud/datastore');
@@ -110,7 +110,7 @@ export class Index {
     callback: IndexGetMetadataCallback
   ): void;
   /**
-   * Get an index if it exists.
+   * Get the metadata of this index.
    *
    * @param {object} [gaxOptions] Request configuration options, outlined here:
    *     https://googleapis.github.io/gax-nodejs/CallSettings.html.

--- a/src/index-class.ts
+++ b/src/index-class.ts
@@ -12,21 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {CallOptions} from 'google-gax';
+import {CallOptions, ServiceError} from 'google-gax';
 import {promisifyAll} from '@google-cloud/promisify';
 
 import {Datastore} from './';
 import {google} from '../protos/protos';
 
 export interface GenericIndexCallback<T> {
-  (err?: Error | null, index?: Index | null, apiResponse?: T | null): void;
+  (
+    err?: ServiceError | null,
+    index?: Index | null,
+    apiResponse?: T | null
+  ): void;
 }
 
 export type GetIndexCallback = GenericIndexCallback<IIndex>;
 export type GetIndexResponse = [Index, IIndex];
 
 export type IndexGetMetadataCallback = (
-  err?: Error | null,
+  err?: ServiceError | null,
   metadata?: IIndex | null
 ) => void;
 export type IndexGetMetadataResponse = [IIndex];
@@ -44,7 +48,7 @@ export type GetIndexesResponse = [
   google.datastore.admin.v1.IListIndexesResponse
 ];
 export type GetIndexesCallback = (
-  err?: Error | null,
+  err?: ServiceError | null,
   indexes?: Index[],
   nextQuery?: GetIndexesOptions,
   apiResponse?: google.datastore.admin.v1.IListIndexesResponse
@@ -67,9 +71,9 @@ export class Index {
   id: string;
   metadata?: IIndex;
 
-  constructor(datastore: Datastore, name: string) {
+  constructor(datastore: Datastore, id: string) {
     this.datastore = datastore;
-    this.id = name.split('/').pop()!;
+    this.id = id.split('/').pop()!;
   }
 
   get(gaxOptions?: CallOptions): Promise<GetIndexResponse>;
@@ -113,7 +117,6 @@ export class Index {
    * @param {function} callback The callback function.
    * @param {?error} callback.err An error returned while making this request.
    * @param {object} callback.metadata The metadata.
-   * @param {object} callback.apiResponse The full API response.
    */
   getMetadata(
     gaxOptionsOrCallback?: CallOptions | IndexGetMetadataCallback,
@@ -137,7 +140,7 @@ export class Index {
         if (resp) {
           this.metadata = resp;
         }
-        callback(err, resp);
+        callback(err as ServiceError, resp);
       }
     );
   }

--- a/src/index-class.ts
+++ b/src/index-class.ts
@@ -1,0 +1,155 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {CallOptions} from 'google-gax';
+import {promisifyAll} from '@google-cloud/promisify';
+
+import {Datastore} from './';
+import {google} from '../protos/protos';
+
+export interface GenericIndexCallback<T> {
+  (err?: Error | null, index?: Index | null, apiResponse?: T | null): void;
+}
+
+export type GetIndexCallback = GenericIndexCallback<IIndex>;
+export type GetIndexResponse = [Index, IIndex];
+
+export type IndexGetMetadataCallback = (
+  err?: Error | null,
+  metadata?: IIndex | null
+) => void;
+export type IndexGetMetadataResponse = [IIndex];
+
+export interface GetIndexesOptions {
+  filter?: string;
+  gaxOptions?: CallOptions;
+  pageSize?: number;
+  pageToken?: string;
+  autoPaginate?: boolean;
+}
+export type GetIndexesResponse = [
+  Index[],
+  GetIndexesOptions,
+  google.datastore.admin.v1.IListIndexesResponse
+];
+export type GetIndexesCallback = (
+  err?: Error | null,
+  indexes?: Index[],
+  nextQuery?: GetIndexesOptions,
+  apiResponse?: google.datastore.admin.v1.IListIndexesResponse
+) => void;
+
+export type IIndex = google.datastore.admin.v1.IIndex;
+
+/**
+ * @class
+ * @param {Datastore} datastore The parent instance of this index.
+ * @param {string} name Name of the index.
+ *
+ * @example
+ * const {Datastore} = require('@google-cloud/datastore');
+ * const datastore = new Datastore();
+ * const index = datastore.index('my-index');
+ */
+export class Index {
+  datastore: Datastore;
+  id: string;
+  metadata?: IIndex;
+
+  constructor(datastore: Datastore, name: string) {
+    this.datastore = datastore;
+    this.id = name.split('/').pop()!;
+  }
+
+  get(gaxOptions?: CallOptions): Promise<GetIndexResponse>;
+  get(callback: GetIndexCallback): void;
+  get(gaxOptions: CallOptions, callback: GetIndexCallback): void;
+  /**
+   * Get an index if it exists.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this request.
+   * @param {Index} callback.index The Index instance.
+   * @param {object} callback.apiResponse The full API response.
+   */
+  get(
+    gaxOptionsOrCallback?: CallOptions | GetIndexCallback,
+    cb?: GetIndexCallback
+  ): void | Promise<GetIndexResponse> {
+    const gaxOpts =
+      typeof gaxOptionsOrCallback === 'object' ? gaxOptionsOrCallback : {};
+    const callback =
+      typeof gaxOptionsOrCallback === 'function' ? gaxOptionsOrCallback : cb!;
+
+    this.getMetadata(gaxOpts, (err, metadata) => {
+      callback(err, err ? null : this, metadata);
+    });
+  }
+
+  getMetadata(gaxOptions?: CallOptions): Promise<IndexGetMetadataResponse>;
+  getMetadata(callback: IndexGetMetadataCallback): void;
+  getMetadata(
+    gaxOptions: CallOptions,
+    callback: IndexGetMetadataCallback
+  ): void;
+  /**
+   * Get an index if it exists.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this request.
+   * @param {object} callback.metadata The metadata.
+   * @param {object} callback.apiResponse The full API response.
+   */
+  getMetadata(
+    gaxOptionsOrCallback?: CallOptions | IndexGetMetadataCallback,
+    cb?: IndexGetMetadataCallback
+  ): void | Promise<IndexGetMetadataResponse> {
+    const gaxOpts =
+      typeof gaxOptionsOrCallback === 'object' ? gaxOptionsOrCallback : {};
+    const callback =
+      typeof gaxOptionsOrCallback === 'function' ? gaxOptionsOrCallback : cb!;
+
+    this.datastore.request_(
+      {
+        client: 'DatastoreAdminClient',
+        method: 'getIndex',
+        reqOpts: {
+          indexId: this.id,
+        },
+        gaxOpts,
+      },
+      (err, resp) => {
+        if (resp) {
+          this.metadata = resp;
+        }
+        callback(err, resp);
+      }
+    );
+  }
+
+  // @TODO implement create()
+  // @TODO implement delete()
+  // @TODO implement exists()
+}
+
+/*! Developer Documentation
+ *
+ * All async methods (except for streams) will return a Promise in the event
+ * that a callback is omitted.
+ */
+promisifyAll(Index);

--- a/src/index.ts
+++ b/src/index.ts
@@ -497,7 +497,17 @@ class Datastore extends DatastoreRequest {
   export(config: ExportEntitiesConfig): Promise<LongRunningResponse>;
   export(config: ExportEntitiesConfig, callback: LongRunningCallback): void;
   /**
+   * Export entities from this project to a Google Cloud Storage bucket.
+   *
    * @param {ExportEntitiesConfig} config Configuration object.
+   * @param {string | Bucket} config.bucket The `gs://bucket` path or a
+   *     @google-cloud/storage Bucket object.
+   * @param {string[]} [config.kinds] The kinds to include in this import.
+   * @param {string[]} [config.namespaces] The namespace IDs to include in this
+   *     import.
+   * @param {object} [config.gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
+   * @param {function} callback The callback function.
    * @param {?error} callback.err An error returned while making this request.
    * @param {Operation} callback.operation An operation object that can be used
    *     to check the status of the request.
@@ -560,7 +570,12 @@ class Datastore extends DatastoreRequest {
   getIndexes(options: GetIndexesOptions, callback: GetIndexesCallback): void;
   getIndexes(callback: GetIndexesCallback): void;
   /**
+   * Get all of the indexes in this project.
+   *
    * @param {GetIndexesOptions | GetIndexesCallback} [optionsOrCallback]
+   * @param {object} [options.gaxOptions] Request configuration options,
+   *     outlined here:
+   *     https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
    * @param {GetIndexesResponse} [callback] The callback function.
    * @param {?error} callback.error An error returned while making this request.
    * @param {Index[]} callback.indexes All matching Index instances.
@@ -626,6 +641,8 @@ class Datastore extends DatastoreRequest {
   }
 
   /**
+   * Get all of the indexes in this project as a readable object stream.
+   *
    * @param {GetIndexesOptions} [options] Configuration object. See
    *     {@link Datastore#getIndexes} for a complete list of options.
    * @returns {ReadableStream<Index>}
@@ -658,7 +675,17 @@ class Datastore extends DatastoreRequest {
   import(config: ImportEntitiesConfig): Promise<LongRunningResponse>;
   import(config: ImportEntitiesConfig, callback: LongRunningCallback): void;
   /**
+   * Import entities into this project from a remote file.
+   *
    * @param {ImportEntitiesConfig} config Configuration object.
+   * @param {string | File} config.file The `gs://bucket/file` path or a
+   *     @google-cloud/storage File object.
+   * @param {string[]} [config.kinds] The kinds to include in this import.
+   * @param {string[]} [config.namespaces] The namespace IDs to include in this
+   *     import.
+   * @param {object} [config.gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
+   * @param {function} callback The callback function.
    * @param {?error} callback.err An error returned while making this request.
    * @param {Operation} callback.operation An operation object that can be used
    *     to check the status of the request.

--- a/src/index.ts
+++ b/src/index.ts
@@ -512,7 +512,7 @@ class Datastore extends DatastoreRequest {
     };
 
     if (reqOpts.bucket && reqOpts.outputUrlPrefix) {
-      throw new Error('Both `bucket` and `outputUrlPrefix` provided.');
+      throw new Error('Both `bucket` and `outputUrlPrefix` were provided.');
     }
 
     if (!reqOpts.outputUrlPrefix) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -526,7 +526,6 @@ class Datastore extends DatastoreRequest {
     }
 
     if (reqOpts.kinds) {
-      console.log(reqOpts.kinds, typeof config.entityFilter);
       if (typeof config.entityFilter === 'object') {
         throw new Error('Both `entityFilter` and `kinds` were provided.');
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -513,7 +513,7 @@ class Datastore extends DatastoreRequest {
 
     if (!reqOpts.outputUrlPrefix) {
       if (typeof config.bucket === 'string') {
-        reqOpts.outputUrlPrefix = `gs://${config.bucket}`;
+        reqOpts.outputUrlPrefix = `gs://${config.bucket.replace('gs://', '')}`;
       } else if (typeof config.bucket === 'object') {
         reqOpts.outputUrlPrefix = `gs://${config.bucket.name}`;
       } else {
@@ -664,7 +664,7 @@ class Datastore extends DatastoreRequest {
 
     if (!reqOpts.inputUrl) {
       if (typeof config.file === 'string') {
-        reqOpts.inputUrl = `gs://${config.file}`;
+        reqOpts.inputUrl = `gs://${config.file.replace('gs://', '')}`;
       } else if (typeof config.file === 'object') {
         reqOpts.inputUrl = `gs://${config.file.bucket.name}/${config.file.name}`;
       } else {

--- a/system-test/datastore.ts
+++ b/system-test/datastore.ts
@@ -15,7 +15,6 @@
 import * as assert from 'assert';
 import {readFileSync} from 'fs';
 import * as path from 'path';
-import Q from 'p-queue';
 import {before, after, describe, it} from 'mocha';
 import * as yaml from 'js-yaml';
 import {Datastore, Index} from '../src';
@@ -993,28 +992,6 @@ describe('Datastore', () => {
   describe('importing and exporting entities', () => {
     const gcs = new Storage();
     const bucket = gcs.bucket('nodejs-datastore-system-tests');
-
-    before(async () => {
-      // Remove stale exported entities.
-      const q = new Q({concurrency: 5});
-      const [files] = await bucket.getFiles();
-      await Promise.all(
-        files.filter(file => {
-          const oneHourAgo = new Date(Date.now() - 3600000);
-          const shouldDelete = file.metadata.timeCreated <= oneHourAgo;
-          if (shouldDelete) {
-            q.add(async () => {
-              try {
-                await file.delete();
-              } catch (e) {
-                console.log(`Error deleting file: ${file.name}`);
-              }
-            });
-          }
-          return shouldDelete;
-        })
-      );
-    });
 
     it('should export, then import entities', async () => {
       const [exportOperation] = await datastore.export({bucket});

--- a/system-test/datastore.ts
+++ b/system-test/datastore.ts
@@ -13,8 +13,14 @@
 // limitations under the License.
 
 import * as assert from 'assert';
+import {readFileSync} from 'fs';
+import * as path from 'path';
+import Q from 'p-queue';
 import {before, after, describe, it} from 'mocha';
-import {Datastore} from '../src';
+import * as yaml from 'js-yaml';
+import {Datastore, Index} from '../src';
+import {google} from '../protos/protos';
+import {Storage} from '@google-cloud/storage';
 
 describe('Datastore', () => {
   const testKinds: string[] = [];
@@ -30,6 +36,13 @@ describe('Datastore', () => {
     testKinds.push(keyObject.kind);
     return keyObject;
   };
+
+  const {indexes: DECLARED_INDEXES} = yaml.safeLoad(
+    readFileSync(path.join(__dirname, 'data', 'index.yaml'), 'utf8')
+  ) as {indexes: google.datastore.admin.v1.IIndex[]};
+
+  // TODO/DX ensure indexes before testing, and maybe? cleanup indexes after
+  //  possible implications with kokoro project
 
   after(async () => {
     async function deleteEntities(kind: string) {
@@ -921,6 +934,109 @@ describe('Datastore', () => {
       await transaction.get(key);
       transaction.save({key, data: {}});
       await assert.rejects(transaction.commit());
+    });
+  });
+
+  describe('indexes', () => {
+    // @TODO: Until the protos support creating indexes, these tests depend on
+    // the remote state of declared indexes. Could be flaky!
+    it('should get all indexes', async () => {
+      const [indexes] = await datastore.getIndexes();
+      assert.ok(
+        indexes.length >= DECLARED_INDEXES.length,
+        'has at least the number of indexes per system-test/data/index.yaml'
+      );
+
+      // Comparing index.yaml and the actual defined index in Datastore requires
+      // assumptions to complete a shape transformation, so let's just see if
+      // a returned index has the right shape and not inspect the values.
+      const [firstIndex] = indexes;
+
+      assert.ok(firstIndex, 'first index is readable');
+      assert.ok(firstIndex.metadata!.properties, 'has properties collection');
+      assert.ok(
+        firstIndex.metadata!.properties.length,
+        'with properties inside'
+      );
+      assert.ok(firstIndex.metadata!.ancestor, 'has the ancestor property');
+    });
+
+    it('should get all indexes as a stream', done => {
+      const indexes: Index[] = [];
+
+      datastore
+        .getIndexesStream()
+        .on('error', done)
+        .on('data', index => {
+          indexes.push(index);
+        })
+        .on('end', () => {
+          assert(indexes.length >= DECLARED_INDEXES.length);
+          done();
+        });
+    });
+
+    it('should get a specific index', async () => {
+      const [indexes] = await datastore.getIndexes();
+      const [firstIndex] = indexes;
+
+      const index = datastore.index(firstIndex.id);
+      const [metadata] = await index.getMetadata();
+      assert.deepStrictEqual(
+        metadata,
+        firstIndex.metadata,
+        'asked index is the same as received index'
+      );
+    });
+  });
+
+  describe('importing and exporting entities', () => {
+    const gcs = new Storage();
+    const bucket = gcs.bucket('nodejs-datastore-system-tests');
+
+    before(async () => {
+      // Remove stale exported entities.
+      const q = new Q({concurrency: 5});
+      const [files] = await bucket.getFiles();
+      await Promise.all(
+        files.filter(file => {
+          const oneHourAgo = new Date(Date.now() - 3600000);
+          const shouldDelete = file.metadata.timeCreated <= oneHourAgo;
+          if (shouldDelete) {
+            q.add(async () => {
+              try {
+                await file.delete();
+              } catch (e) {
+                console.log(`Error deleting file: ${file.name}`);
+              }
+            });
+          }
+          return shouldDelete;
+        })
+      );
+    });
+
+    it('should export, then import entities', async () => {
+      const [exportOperation] = await datastore.export({bucket});
+      await exportOperation.promise();
+
+      const [files] = await bucket.getFiles({maxResults: 1});
+      const [exportedFile] = files;
+      assert.ok(exportedFile.name.includes('overall_export_metadata'));
+
+      const [importOperation] = await datastore.import({
+        file: exportedFile,
+      });
+
+      // This is a >20 minute operation, so we're just going to make sure the
+      // right type of operation was started.
+      assert.strictEqual(
+        (importOperation.metadata as google.datastore.admin.v1.IImportEntitiesMetadata)
+          .inputUrl,
+        `gs://${exportedFile.bucket.name}/${exportedFile.name}`
+      );
+
+      await importOperation.cancel();
     });
   });
 });

--- a/test/index-class.ts
+++ b/test/index-class.ts
@@ -1,0 +1,153 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as promisify from '@google-cloud/promisify';
+import * as assert from 'assert';
+import {before, beforeEach, describe, it} from 'mocha';
+import * as proxyquire from 'proxyquire';
+
+import * as ds from '../src';
+
+let promisified = false;
+const fakePromisify = Object.assign({}, promisify, {
+  promisifyAll(klass: Function) {
+    if (klass.name === 'Index') {
+      promisified = true;
+    }
+  },
+});
+
+describe('Index', () => {
+  const INDEX_ID = 'my-index';
+  let DATASTORE: ds.Datastore;
+
+  let Index: typeof ds.Index;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let index: any;
+
+  before(() => {
+    Index = proxyquire('../src/index-class.js', {
+      '@google-cloud/promisify': fakePromisify,
+    }).Index;
+  });
+
+  beforeEach(() => {
+    DATASTORE = {} as ds.Datastore;
+    index = new Index(DATASTORE, INDEX_ID);
+  });
+
+  describe('instantiation', () => {
+    it('should promisify all the things', () => {
+      assert(promisified);
+    });
+
+    it('should localize datastore instance', () => {
+      assert.strictEqual(index.datastore, DATASTORE);
+    });
+
+    it('should localize id from name', () => {
+      const name = 'long/formatted/name';
+      const index = new Index(DATASTORE, name);
+      assert.strictEqual(index.id, name.split('/').pop());
+    });
+
+    it('should localize id from id', () => {
+      assert.strictEqual(index.id, INDEX_ID);
+    });
+  });
+
+  describe('get', () => {
+    it('should call getMetadata', done => {
+      const gaxOptions = {};
+      index.getMetadata = (options: {}) => {
+        assert.strictEqual(options, gaxOptions);
+        done();
+      };
+      index.get(gaxOptions, assert.ifError);
+    });
+
+    it('should not require an options object', done => {
+      index.getMetadata = (options: {}) => {
+        assert.deepStrictEqual(options, {});
+        done();
+      };
+      index.get(assert.ifError);
+    });
+
+    it('should return an error from getMetadata', done => {
+      const error = new Error('Error.');
+      index.getMetadata = (gaxOptions: {}, callback: Function) => {
+        callback(error);
+      };
+      index.get((err: Error | null) => {
+        assert.strictEqual(err, error);
+        done();
+      });
+    });
+
+    it('should return self and API response', done => {
+      const apiResponse = {};
+      index.getMetadata = (gaxOptions: {}, callback: Function) => {
+        callback(null, apiResponse);
+      };
+      index.get((err: Error | null, _index: {}, _apiResponse: {}) => {
+        assert.ifError(err);
+        assert.strictEqual(_index, index);
+        assert.strictEqual(_apiResponse, apiResponse);
+        done();
+      });
+    });
+  });
+
+  describe('getMetadata', () => {
+    it('should make the correct request', done => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      index.datastore.request_ = (config: any) => {
+        assert.strictEqual(config.client, 'DatastoreAdminClient');
+        assert.strictEqual(config.method, 'getIndex');
+        assert.deepStrictEqual(config.reqOpts, {
+          indexId: index.id,
+        });
+        assert.deepStrictEqual(config.gaxOpts, {});
+        done();
+      };
+
+      index.getMetadata(assert.ifError);
+    });
+
+    it('should accept gaxOptions', done => {
+      const gaxOptions = {};
+
+      index.datastore.request_ = (config: {gaxOpts: {}}) => {
+        assert.strictEqual(config.gaxOpts, gaxOptions);
+        done();
+      };
+
+      index.getMetadata(gaxOptions, assert.ifError);
+    });
+
+    it('should update the metadata', done => {
+      const response = {};
+      index.datastore.request_ = (config: {}, callback: Function) => {
+        callback(null, response);
+      };
+      index.getMetadata((err: Error | null, metadata: {}) => {
+        assert.ifError(err);
+        assert.strictEqual(metadata, response);
+        assert.strictEqual(index.metadata, response);
+        done();
+      });
+    });
+  });
+});

--- a/test/index.ts
+++ b/test/index.ts
@@ -541,6 +541,18 @@ describe('Datastore', () => {
       datastore.export({bucket}, assert.ifError);
     });
 
+    it('should remove extraneous gs:// prefix from input', done => {
+      const bucket = 'gs://bucket';
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      datastore.request_ = (config: any) => {
+        assert.strictEqual(config.reqOpts.outputUrlPrefix, `${bucket}`);
+        done();
+      };
+
+      datastore.export({bucket}, assert.ifError);
+    });
+
     it('should accept a Bucket object destination', done => {
       const bucket = {name: 'bucket'};
 
@@ -931,6 +943,18 @@ describe('Datastore', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       datastore.request_ = (config: any) => {
         assert.strictEqual(config.reqOpts.inputUrl, `gs://${file}`);
+        done();
+      };
+
+      datastore.import({file}, assert.ifError);
+    });
+
+    it('should remove extraneous gs:// prefix from input', done => {
+      const file = 'gs://file';
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      datastore.request_ = (config: any) => {
+        assert.strictEqual(config.reqOpts.inputUrl, `${file}`);
         done();
       };
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -571,7 +571,7 @@ describe('Datastore', () => {
     it('should throw if a destination is not provided', () => {
       assert.throws(() => {
         datastore.export({}, assert.ifError);
-      }, /An output URL must be provided\./);
+      }, /A Bucket object or URL must be provided\./);
     });
 
     it('should accept kinds', done => {
@@ -585,6 +585,19 @@ describe('Datastore', () => {
       };
 
       datastore.export(config, assert.ifError);
+    });
+
+    it('should throw if both kinds and entityFilter are provided', () => {
+      assert.throws(() => {
+        datastore.export(
+          {
+            bucket: 'bucket',
+            kinds: ['kind1', 'kind2'],
+            entityFilter: {},
+          },
+          assert.ifError
+        );
+      }, /Both `entityFilter` and `kinds` were provided\./);
     });
 
     it('should accept namespaces', done => {
@@ -601,6 +614,19 @@ describe('Datastore', () => {
       };
 
       datastore.export(config, assert.ifError);
+    });
+
+    it('should throw if both namespaces and entityFilter are provided', () => {
+      assert.throws(() => {
+        datastore.export(
+          {
+            bucket: 'bucket',
+            namespaces: ['ns1', 'ns2'],
+            entityFilter: {},
+          },
+          assert.ifError
+        );
+      }, /Both `entityFilter` and `namespaces` were provided\./);
     });
 
     it('should remove extraneous properties from request', done => {
@@ -937,6 +963,18 @@ describe('Datastore', () => {
   });
 
   describe('import', () => {
+    it('should throw if both file and inputUrl are provided', () => {
+      assert.throws(() => {
+        datastore.import(
+          {
+            file: 'file',
+            inputUrl: 'gs://file',
+          },
+          assert.ifError
+        );
+      }, /Both `file` and `inputUrl` were provided\./);
+    });
+
     it('should accept a file string source', done => {
       const file = 'file';
 
@@ -995,6 +1033,19 @@ describe('Datastore', () => {
       datastore.import(config, assert.ifError);
     });
 
+    it('should throw if both kinds and entityFilter are provided', () => {
+      assert.throws(() => {
+        datastore.import(
+          {
+            file: 'file',
+            kinds: ['kind1', 'kind2'],
+            entityFilter: {},
+          },
+          assert.ifError
+        );
+      }, /Both `entityFilter` and `kinds` were provided\./);
+    });
+
     it('should accept namespaces', done => {
       const namespaces = ['ns1', 'n2'];
       const config = {file: 'file', namespaces};
@@ -1009,6 +1060,19 @@ describe('Datastore', () => {
       };
 
       datastore.import(config, assert.ifError);
+    });
+
+    it('should throw if both namespaces and entityFilter are provided', () => {
+      assert.throws(() => {
+        datastore.import(
+          {
+            file: 'file',
+            namespaces: ['ns1', 'ns2'],
+            entityFilter: {},
+          },
+          assert.ifError
+        );
+      }, /Both `entityFilter` and `namespaces` were provided\./);
     });
 
     it('should remove extraneous properties from request', done => {

--- a/test/index.ts
+++ b/test/index.ts
@@ -574,6 +574,18 @@ describe('Datastore', () => {
       }, /A Bucket object or URL must be provided\./);
     });
 
+    it('should throw if bucket and outputUrlPrefix are provided', () => {
+      assert.throws(() => {
+        datastore.export(
+          {
+            bucket: 'bucket',
+            outputUrlPrefix: 'output-url-prefix',
+          },
+          assert.ifError
+        );
+      }, /Both `bucket` and `outputUrlPrefix` were provided\./);
+    });
+
     it('should accept kinds', done => {
       const kinds = ['kind1', 'kind2'];
       const config = {bucket: 'bucket', kinds};

--- a/test/index.ts
+++ b/test/index.ts
@@ -16,6 +16,7 @@ import * as assert from 'assert';
 import {before, beforeEach, after, afterEach, describe, it} from 'mocha';
 import * as gax from 'google-gax';
 import * as proxyquire from 'proxyquire';
+import {PassThrough, Readable} from 'stream';
 
 import * as ds from '../src';
 import {DatastoreOptions} from '../src';
@@ -106,6 +107,14 @@ const fakeGoogleGax = {
   },
 };
 
+class FakeIndex {
+  calledWith_: Array<{}>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  constructor(...args: any[]) {
+    this.calledWith_ = args;
+  }
+}
+
 class FakeQuery {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   calledWith_: any[];
@@ -150,6 +159,7 @@ describe('Datastore', () => {
   before(() => {
     Datastore = proxyquire('../src', {
       './entity.js': {entity: fakeEntity},
+      './index-class.js': {Index: FakeIndex},
       './query.js': {Query: FakeQuery},
       './transaction.js': {Transaction: FakeTransaction},
       './v1': FakeV1,
@@ -515,6 +525,538 @@ describe('Datastore', () => {
       assert.strictEqual(query.calledWith_[0], datastore);
       assert.strictEqual(query.calledWith_[1], datastore.namespace);
       assert.deepStrictEqual(query.calledWith_[2], []);
+    });
+  });
+
+  describe('export', () => {
+    it('should accept a bucket string destination', done => {
+      const bucket = 'bucket';
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      datastore.request_ = (config: any) => {
+        assert.strictEqual(config.reqOpts.outputUrlPrefix, `gs://${bucket}`);
+        done();
+      };
+
+      datastore.export({bucket}, assert.ifError);
+    });
+
+    it('should accept a Bucket object destination', done => {
+      const bucket = {name: 'bucket'};
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      datastore.request_ = (config: any) => {
+        assert.strictEqual(
+          config.reqOpts.outputUrlPrefix,
+          `gs://${bucket.name}`
+        );
+        done();
+      };
+
+      datastore.export({bucket}, assert.ifError);
+    });
+
+    it('should throw if a destination is not provided', () => {
+      assert.throws(() => {
+        datastore.export({}, assert.ifError);
+      }, /An output URL must be provided\./);
+    });
+
+    it('should accept kinds', done => {
+      const kinds = ['kind1', 'kind2'];
+      const config = {bucket: 'bucket', kinds};
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      datastore.request_ = (config: any) => {
+        assert.deepStrictEqual(config.reqOpts.entityFilter.kinds, kinds);
+        done();
+      };
+
+      datastore.export(config, assert.ifError);
+    });
+
+    it('should accept namespaces', done => {
+      const namespaces = ['ns1', 'n2'];
+      const config = {bucket: 'bucket', namespaces};
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      datastore.request_ = (config: any) => {
+        assert.deepStrictEqual(
+          config.reqOpts.entityFilter.namespaceIds,
+          namespaces
+        );
+        done();
+      };
+
+      datastore.export(config, assert.ifError);
+    });
+
+    it('should remove extraneous properties from request', done => {
+      const config = {
+        bucket: 'bucket',
+        gaxOptions: {},
+        kinds: ['kind1', 'kind2'],
+        namespaces: ['ns1', 'ns2'],
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      datastore.request_ = (config: any) => {
+        assert.strictEqual(typeof config.reqOpts.bucket, 'undefined');
+        assert.strictEqual(typeof config.reqOpts.gaxOptions, 'undefined');
+        assert.strictEqual(typeof config.reqOpts.kinds, 'undefined');
+        assert.strictEqual(typeof config.reqOpts.namespaces, 'undefined');
+        done();
+      };
+
+      datastore.export(config, assert.ifError);
+    });
+
+    it('should send any user input to API', done => {
+      const userProperty = 'abc';
+      const config = {bucket: 'bucket', userProperty};
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      datastore.request_ = (config: any) => {
+        assert.strictEqual(config.reqOpts.userProperty, userProperty);
+        done();
+      };
+
+      datastore.export(config, assert.ifError);
+    });
+
+    it('should send correct request', done => {
+      const config = {bucket: 'bucket'};
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      datastore.request_ = (config: any) => {
+        assert.strictEqual(config.client, 'DatastoreAdminClient');
+        assert.strictEqual(config.method, 'exportEntities');
+        assert.strictEqual(typeof config.gaxOpts, 'undefined');
+        done();
+      };
+
+      datastore.export(config, assert.ifError);
+    });
+
+    it('should accept gaxOptions', done => {
+      const gaxOptions = {};
+      const config = {bucket: 'bucket', gaxOptions};
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      datastore.request_ = (config: any) => {
+        assert.strictEqual(config.gaxOpts, gaxOptions);
+        done();
+      };
+
+      datastore.export(config, assert.ifError);
+    });
+  });
+
+  describe('getIndexes', () => {
+    it('should send the correct request', done => {
+      const options = {a: 'b'};
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      datastore.request_ = (config: any) => {
+        assert.strictEqual(config.client, 'DatastoreAdminClient');
+        assert.strictEqual(config.method, 'listIndexes');
+        assert.deepStrictEqual(config.reqOpts, {
+          pageSize: undefined,
+          pageToken: undefined,
+          ...options,
+        });
+        assert.deepStrictEqual(config.gaxOpts, {});
+
+        done();
+      };
+
+      datastore.getIndexes(options, assert.ifError);
+    });
+
+    it('should locate pagination settings from gaxOptions', done => {
+      const options = {
+        gaxOptions: {
+          pageSize: 'size',
+          pageToken: 'token',
+        },
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      datastore.request_ = (config: any) => {
+        assert.strictEqual(
+          config.reqOpts.pageSize,
+          options.gaxOptions.pageSize
+        );
+        assert.strictEqual(
+          config.reqOpts.pageToken,
+          options.gaxOptions.pageToken
+        );
+        done();
+      };
+
+      datastore.getIndexes(options, assert.ifError);
+    });
+
+    it('should prefer pageSize and pageToken from options over gaxOptions', done => {
+      const options = {
+        pageSize: 'size-good',
+        pageToken: 'token-good',
+        gaxOptions: {
+          pageSize: 'size-bad',
+          pageToken: 'token-bad',
+        },
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      datastore.request_ = (config: any) => {
+        assert.strictEqual(config.reqOpts.pageSize, options.pageSize);
+        assert.strictEqual(config.reqOpts.pageToken, options.pageToken);
+        done();
+      };
+
+      datastore.getIndexes(options, assert.ifError);
+    });
+
+    it('should remove extraneous pagination settings from request', done => {
+      const options = {
+        gaxOptions: {
+          pageSize: 'size',
+          pageToken: 'token',
+        },
+        autoPaginate: true,
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      datastore.request_ = (config: any) => {
+        assert.strictEqual(typeof config.gaxOpts.pageSize, 'undefined');
+        assert.strictEqual(typeof config.gaxOpts.pageToken, 'undefined');
+        assert.strictEqual(typeof config.reqOpts.autoPaginate, 'undefined');
+        done();
+      };
+
+      datastore.getIndexes(options, assert.ifError);
+    });
+
+    it('should accept gaxOptions', done => {
+      const options = {
+        gaxOptions: {a: 'b'},
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      datastore.request_ = (config: any) => {
+        assert.strictEqual(typeof config.reqOpts.gaxOptions, 'undefined');
+        assert.deepStrictEqual(config.gaxOpts, options.gaxOptions);
+        done();
+      };
+
+      datastore.getIndexes(options, assert.ifError);
+    });
+
+    it('should not send gaxOptions as request options', done => {
+      const options = {
+        gaxOptions: {a: 'b'},
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      datastore.request_ = (config: any) => {
+        assert(Object.keys(options.gaxOptions).every(k => !config.reqOpts[k]));
+        done();
+      };
+
+      datastore.getIndexes(options, assert.ifError);
+    });
+
+    it('should set autoPaginate from options', done => {
+      const options = {
+        autoPaginate: true,
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      datastore.request_ = (config: any) => {
+        assert.strictEqual(config.gaxOpts.autoPaginate, options.autoPaginate);
+        done();
+      };
+
+      datastore.getIndexes(options, assert.ifError);
+    });
+
+    it('should prefer autoPaginate from gaxOpts', done => {
+      const options = {
+        autoPaginate: false,
+        gaxOptions: {
+          autoPaginate: true,
+        },
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      datastore.request_ = (config: any) => {
+        assert.strictEqual(config.gaxOpts.autoPaginate, true);
+        done();
+      };
+
+      datastore.getIndexes(options, assert.ifError);
+    });
+
+    it('should execute callback with error and correct response arguments', done => {
+      const error = new Error('Error.');
+      const apiResponse = {};
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      datastore.request_ = (config: any, callback: Function) => {
+        callback(error, [], null, apiResponse);
+      };
+
+      datastore.getIndexes(
+        (err: Error, indexes: [], nextQuery: {}, apiResp: {}) => {
+          assert.strictEqual(err, error);
+          assert.deepStrictEqual(indexes, []);
+          assert.strictEqual(nextQuery, null);
+          assert.strictEqual(apiResp, apiResponse);
+          done();
+        }
+      );
+    });
+
+    it('should execute callback with Index instances', done => {
+      const rawIndex = {indexId: 'name', a: 'b'};
+      const indexInstance = {};
+
+      datastore.index = (id: string) => {
+        assert.strictEqual(id, rawIndex.indexId);
+        return indexInstance;
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      datastore.request_ = (config: any, callback: Function) => {
+        callback(null, [rawIndex]);
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      datastore.getIndexes((err: Error, indexes: any[]) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(indexes, [indexInstance]);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        assert.strictEqual((indexes[0] as any)!.metadata, rawIndex);
+        done();
+      });
+    });
+
+    it('should execute callback with prepared nextQuery', done => {
+      const options = {pageToken: '1'};
+      const nextQuery = {pageToken: '2'};
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      datastore.request_ = (config: any, callback: Function) => {
+        callback(null, [], nextQuery);
+      };
+
+      datastore.getIndexes(
+        options,
+        (err: Error, indexes: [], _nextQuery: {}) => {
+          assert.ifError(err);
+          assert.deepStrictEqual(_nextQuery, nextQuery);
+          done();
+        }
+      );
+    });
+  });
+
+  describe('getIndexesStream', () => {
+    it('should make correct request', done => {
+      const options = {a: 'b'};
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      datastore.requestStream_ = (config: any) => {
+        assert.strictEqual(config.client, 'DatastoreAdminClient');
+        assert.strictEqual(config.method, 'listIndexesStream');
+        assert.deepStrictEqual(config.reqOpts, {
+          ...options,
+        });
+        assert.strictEqual(typeof config.gaxOpts, 'undefined');
+        setImmediate(done);
+        return new PassThrough();
+      };
+
+      datastore.getIndexesStream(options);
+    });
+
+    it('should accept gaxOptions', done => {
+      const options = {gaxOptions: {}};
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      datastore.requestStream_ = (config: any) => {
+        assert.strictEqual(config.gaxOpts, options.gaxOptions);
+        setImmediate(done);
+        return new PassThrough();
+      };
+
+      datastore.getIndexesStream(options);
+    });
+
+    it('should transform response indexes into Index objects', done => {
+      const rawIndex = {indexId: 'name', a: 'b'};
+      const indexInstance = {};
+      const requestStream = new Readable({
+        objectMode: true,
+        read() {
+          this.push(rawIndex);
+          this.push(null);
+        },
+      });
+
+      datastore.index = (id: string) => {
+        assert.strictEqual(id, rawIndex.indexId);
+        return indexInstance;
+      };
+
+      datastore.requestStream_ = () => requestStream;
+
+      datastore
+        .getIndexesStream()
+        .on('error', done)
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .on('data', (index: any) => {
+          assert.strictEqual(index, indexInstance);
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          assert.strictEqual((index as any).metadata, rawIndex);
+          done();
+        });
+    });
+  });
+
+  describe('import', () => {
+    it('should accept a file string source', done => {
+      const file = 'file';
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      datastore.request_ = (config: any) => {
+        assert.strictEqual(config.reqOpts.inputUrl, `gs://${file}`);
+        done();
+      };
+
+      datastore.import({file}, assert.ifError);
+    });
+
+    it('should accept a File object source', done => {
+      const file = {bucket: {name: 'bucket'}, name: 'file'};
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      datastore.request_ = (config: any) => {
+        assert.strictEqual(
+          config.reqOpts.inputUrl,
+          `gs://${file.bucket.name}/${file.name}`
+        );
+        done();
+      };
+
+      datastore.import({file}, assert.ifError);
+    });
+
+    it('should throw if a source is not provided', () => {
+      assert.throws(() => {
+        datastore.import({}, assert.ifError);
+      }, /An input URL must be provided\./);
+    });
+
+    it('should accept kinds', done => {
+      const kinds = ['kind1', 'kind2'];
+      const config = {file: 'file', kinds};
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      datastore.request_ = (config: any) => {
+        assert.deepStrictEqual(config.reqOpts.entityFilter.kinds, kinds);
+        done();
+      };
+
+      datastore.import(config, assert.ifError);
+    });
+
+    it('should accept namespaces', done => {
+      const namespaces = ['ns1', 'n2'];
+      const config = {file: 'file', namespaces};
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      datastore.request_ = (config: any) => {
+        assert.deepStrictEqual(
+          config.reqOpts.entityFilter.namespaceIds,
+          namespaces
+        );
+        done();
+      };
+
+      datastore.import(config, assert.ifError);
+    });
+
+    it('should remove extraneous properties from request', done => {
+      const config = {
+        file: 'file',
+        gaxOptions: {},
+        kinds: ['kind1', 'kind2'],
+        namespaces: ['ns1', 'ns2'],
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      datastore.request_ = (config: any) => {
+        assert.strictEqual(typeof config.reqOpts.file, 'undefined');
+        assert.strictEqual(typeof config.reqOpts.gaxOptions, 'undefined');
+        assert.strictEqual(typeof config.reqOpts.kinds, 'undefined');
+        assert.strictEqual(typeof config.reqOpts.namespaces, 'undefined');
+        done();
+      };
+
+      datastore.import(config, assert.ifError);
+    });
+
+    it('should send any user input to API', done => {
+      const userProperty = 'abc';
+      const config = {file: 'file', userProperty};
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      datastore.request_ = (config: any) => {
+        assert.strictEqual(config.reqOpts.userProperty, userProperty);
+        done();
+      };
+
+      datastore.import(config, assert.ifError);
+    });
+
+    it('should send correct request', done => {
+      const config = {file: 'file'};
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      datastore.request_ = (config: any) => {
+        assert.strictEqual(config.client, 'DatastoreAdminClient');
+        assert.strictEqual(config.method, 'importEntities');
+        assert.strictEqual(typeof config.gaxOpts, 'undefined');
+        done();
+      };
+
+      datastore.import(config, assert.ifError);
+    });
+
+    it('should accept gaxOptions', done => {
+      const gaxOptions = {};
+      const config = {file: 'file', gaxOptions};
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      datastore.request_ = (config: any) => {
+        assert.strictEqual(config.gaxOpts, gaxOptions);
+        done();
+      };
+
+      datastore.import(config, assert.ifError);
+    });
+  });
+
+  describe('index', () => {
+    it('should return an Index object', () => {
+      const indexId = 'index-id';
+      const index = datastore.index(indexId);
+      assert(index instanceof FakeIndex);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const args = (index as any).calledWith_;
+      assert.strictEqual(args[0], datastore);
+      assert.strictEqual(args[1], indexId);
     });
   });
 


### PR DESCRIPTION
Fixes #685
Closes #687

### Indexes

#### References
- ["Index" type](https://cloud.google.com/datastore/docs/reference/admin/rpc/google.datastore.admin.v1#index_2) as seen in code samples below, aliased by "index.metadata"

An "Index" is a custom object in our library, which allows additional methods that are consistent across all of our libraries:

- `index.getMetadata()`
- `index.get()`

It can also be expanded to allow these methods in the future (where applicable):

- `index.create()`
- `index.delete()`
- `index.exists()`

#### Get an array of Index objects
```js
const [indexes] = await datastore.getIndexes();
for (const index of indexes) {
  console.log(index.metadata); // "Index" type
}
```

#### Get a single Index
```js
const index = datastore.index('index-id');
const [metadata] = await index.getMetadata();
console.log(metadata); // "Index" type

// Or...

const [index] = datastore.index('index-id').get();
console.log(index.metadata); // "Index" type
```

### Importing entities
- `config` accepts all properties of an [`ImportEntitiesRequest`](https://cloud.google.com/datastore/docs/reference/admin/rpc/google.datastore.admin.v1#importentitiesrequest), along with custom shortcut properties:
  - `file`: A "File" object from the @googleapis/nodejs-storage library, or a string gs:// file path (maps to `inputUrl`)
  - `kinds`: An array of string kinds (maps to `entityFilter.kinds`)
  - `namespaces`: An array of namespace IDs (maps to `entityFiler.namespaceIds`)

```js
const [operation] = datastore.import(config);
await operation.promise();
// Entities successfully imported
```

### Exporting entities
- `config` accepts all properties of an [`ExportEntitiesRequest`](https://cloud.google.com/datastore/docs/reference/admin/rpc/google.datastore.admin.v1#exportentitiesrequest), along with custom shortcut properties:
  - `bucket`: A "Bucket" object from the @googleapis/nodejs-storage library, or a string bucket name (maps to `outputUrlPrefix`)
  - `kinds`: An array of string kinds (maps to `entityFilter.kinds`)
  - `namespaces`: An array of namespace IDs (maps to `entityFiler.namespaceIds`)

```js
const [operation] = datastore.export(config);
await operation.promise();
const createdFilePath = operation.result.outputUrl;
```

#### Testing Info

As the import and export operations only work with a Storage bucket, I've created one `nodejs-datastore-system-tests`, and granted access to the service account. That bucket is self-cleaning thanks to lifecycle rules, so the tests don't have any before/after hook cleanup task. The rule will delete 1-day old objects automatically.

#### To Dos
- [x] Implement new Index class
- [x] Add `datastore.export()`
- [x] Add `datastore.import()`
- [x] System tests
- [x] Unit tests
- [x] Samples
- [x] Sample tests
- [x] JSDocs