### PR TITLE
docs: correct method name referenced by datastore.merge()

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -816,7 +816,7 @@ class DatastoreRequest {
    * By default, all properties are indexed. To prevent a property from being
    * included in *all* indexes, you must supply an `excludeFromIndexes` array.
    *
-   * Maps to {@link Datastore#save}, forcing the method to be `merge`.
+   * Maps to {@link Datastore#save}, forcing the method to be `upsert`.
    *
    * @param {object|object[]} entities Datastore key object(s).
    * @param {Key} entities.key Datastore key object.


### PR DESCRIPTION
`merge` is not a method of `Datastore#save`.

The method is set to `upsert` on l 856.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Appropriate docs were updated (if necessary)
