### PR TITLE
fix: storing an empty Buffer

### DIFF
--- a/src/entity.ts
+++ b/src/entity.ts
@@ -629,7 +629,10 @@ export namespace entity {
     }
 
     if (value instanceof Buffer) {
-      valueProto.blobValue = value;
+      // Convert the buffer to a base 64 string to workaround a bug of
+      // protobufs encoding empty buffer.
+      // See https://github.com/googleapis/nodejs-datastore/issues/755
+      valueProto.blobValue = value.toString('base64');
       return valueProto;
     }
 

--- a/system-test/datastore.ts
+++ b/system-test/datastore.ts
@@ -326,6 +326,20 @@ describe('Datastore', () => {
       await datastore.delete(datastore.key(['Post', assignedId as string]));
     });
 
+    it('should save/get/delete an empty buffer', async () => {
+      const postKey = datastore.key(['Post']);
+      const data = {
+        buf: Buffer.from([]),
+      };
+      await datastore.save({key: postKey, data});
+      const assignedId = postKey.id;
+      assert(assignedId);
+      const [entity] = await datastore.get(postKey);
+      delete entity[datastore.KEY];
+      assert.deepStrictEqual(entity, data);
+      await datastore.delete(datastore.key(['Post', assignedId as string]));
+    });
+
     it('should save/get/delete with a generated key id', async () => {
       const postKey = datastore.key('Post');
       await datastore.save({key: postKey, data: post});

--- a/test/entity.ts
+++ b/test/entity.ts
@@ -849,7 +849,7 @@ describe('entity', () => {
       const value = Buffer.from('Hi');
 
       const expectedValueProto = {
-        blobValue: value,
+        blobValue: value.toString('base64'),
       };
 
       assert.deepStrictEqual(entity.encodeValue(value), expectedValueProto);


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-datastore/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

As discussed in #755 datastore can not currently store an empty buffer due to a bug in protobufjs - see protobufjs/protobuf.js#1500.

However protobufs supports 2 way of passing a buffer, as seen in [converter.js](https://github.com/protobufjs/protobuf.js/blob/aea41b87da59939b51b5bab89cc0180c8838f8ab/src/converter.js#L71-L75):

```javascript
            case "bytes": gen
                ("if(typeof d%s===\"string\")", prop)
                    ("util.base64.decode(d%s,m%s=util.newBuffer(util.base64.length(d%s)),0)", prop, prop, prop)
                ("else if(d%s.length)", prop)
                    ("m%s=d%s", prop, prop);
```

This PR switch from passing a `Buffer` (the else branch in the snippet above) to passing a base64 encoded string (the if branch in the snippet above).

Encoding/Decoding a non empty buffer was already tested and I added a test for encoding/decoding an empty buffer. As expected the test fails with the current code:

```
  1) Datastore
       create, retrieve and delete
         should save/get/delete an empty buffer:
     Error: 3 INVALID_ARGUMENT: The value "buf" does not contain a value.
```

I am not sure if #755 should be marked as fixed or if we should wait for protobufs to be fixed ?

