### PR TITLE
fix!: don't unwrap int, double by default, add a warning when a number is autoconverted to double or int

### DIFF
--- a/src/entity.ts
+++ b/src/entity.ts
@@ -52,27 +52,46 @@ export namespace entity {
    * provided.
    *
    * @class
-   * @param {number} value The double value.
+   * @param {number|string} value The double value.
    *
    * @example
    * const {Datastore} = require('@google-cloud/datastore');
    * const datastore = new Datastore();
    * const aDouble = datastore.double(7.3);
    */
-  export class Double {
+  export class Double extends Number {
+    private _entityPropertyName: string | undefined;
     type: string;
-    value: number;
-    constructor(value: number) {
+    value: string;
+    constructor(value: number | string | ValueProto) {
+      super(typeof value === 'object' ? value.doubleValue : value);
+
       /**
        * @name Double#type
        * @type {string}
        */
       this.type = 'DatastoreDouble';
+
+      this._entityPropertyName =
+        typeof value === 'object' ? value.propertyName : undefined;
+
       /**
        * @name Double#value
-       * @type {number}
+       * @type {string}
        */
-      this.value = value;
+      this.value =
+        typeof value === 'object'
+          ? value.doubleValue.toString()
+          : value.toString();
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    valueOf(): any {
+      return Number(this.value);
+    }
+
+    toJSON(): Json {
+      return {type: this.type, value: this.value};
     }
   }
 

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -16,12 +16,11 @@
 import arrify = require('arrify');
 import * as extend from 'extend';
 import * as is from 'is';
-import {Query, QueryProto, IntegerTypeCastOptions} from './query';
-import {PathType} from '.';
-import {protobuf as Protobuf} from 'google-gax';
+import { Query, QueryProto, IntegerTypeCastOptions } from './query';
+import { PathType } from '.';
+import { protobuf as Protobuf } from 'google-gax';
 import * as path from 'path';
-import {google} from '../protos/protos';
-import {type} from 'os';
+import { google } from '../protos/protos';
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace entity {
@@ -34,7 +33,7 @@ export namespace entity {
       const errorMessages = {
         MISSING_KIND: 'A key should contain at least a kind.',
         MISSING_ANCESTOR_ID: 'Ancestor keys require an id or name.',
-      } as {[index: string]: string};
+      } as { [index: string]: string };
       super(errorMessages[opts.code]);
       this.name = 'InvalidKey';
     }
@@ -189,7 +188,7 @@ export namespace entity {
     }
 
     toJSON(): Json {
-      return {type: this.type, value: this.value};
+      return { type: this.type, value: this.value };
     }
   }
 
@@ -447,16 +446,16 @@ export namespace entity {
     if (!Number.isSafeInteger(num)) {
       throw new Error(
         'We attempted to return all of the numeric values, but ' +
-          (value.propertyName ? value.propertyName + ' ' : '') +
-          'value ' +
-          value.integerValue +
-          " is out of bounds of 'Number.MAX_SAFE_INTEGER'.\n" +
-          "To prevent this error, please consider passing 'options.wrapNumbers=true' or\n" +
-          "'options.wrapNumbers' as\n" +
-          '{\n' +
-          '  integerTypeCastFunction: provide <your_custom_function>\n' +
-          '  properties: optionally specify property name(s) to be custom casted\n' +
-          '}\n'
+        (value.propertyName ? value.propertyName + ' ' : '') +
+        'value ' +
+        value.integerValue +
+        " is out of bounds of 'Number.MAX_SAFE_INTEGER'.\n" +
+        "To prevent this error, please consider passing 'options.wrapNumbers=true' or\n" +
+        "'options.wrapNumbers' as\n" +
+        '{\n' +
+        '  integerTypeCastFunction: provide <your_custom_function>\n' +
+        '  properties: optionally specify property name(s) to be custom casted\n' +
+        '}\n'
       );
     }
     return num;
@@ -611,13 +610,13 @@ export namespace entity {
         if (!Number.isSafeInteger(value)) {
           process.emitWarning(integerOutOfBoundsWarning);
         } else {
-          process.emitWarning(typeCastWarning);
+          warn('TypeCastWarning', typeCastWarning);
         }
         value = new entity.Int(value);
         valueProto.integerValue = value.value;
         return valueProto;
       } else {
-        process.emitWarning(typeCastWarning);
+        warn('TypeCastWarning', typeCastWarning);
         value = new entity.Double(value);
         valueProto.doubleValue = value.value;
         return valueProto;
@@ -682,6 +681,15 @@ export namespace entity {
     }
 
     throw new Error('Unsupported field value, ' + value + ', was provided.');
+  }
+
+  const warningTypesIssued = new Set<string>();
+  const warn = (warningName: string, warningMessage: string) => {
+    console.log(warningName);
+    if (!warningTypesIssued.has(warningName)) {
+      warningTypesIssued.add(warningName);
+      process.emitWarning(warningMessage);
+    }
   }
 
   /**
@@ -1334,7 +1342,7 @@ export namespace entity {
       const reference = {
         app: projectId,
         namespace: key.namespace,
-        path: {element: elements},
+        path: { element: elements },
       };
 
       const buffer = this.protos.Reference.encode(reference).finish();
@@ -1431,7 +1439,7 @@ export interface ValueProto {
 
 export interface EntityProto {
   key?: KeyProto | null;
-  properties?: {[k: string]: ValueProto};
+  properties?: { [k: string]: ValueProto };
   excludeFromIndexes?: boolean;
 }
 
@@ -1455,7 +1463,7 @@ export interface ResponseResult {
 }
 
 export interface EntityObject {
-  data: {[k: string]: Entity};
+  data: { [k: string]: Entity };
   excludeFromIndexes: string[];
 }
 

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -475,7 +475,7 @@ export namespace entity {
    *
    * @private
    * @param {object} valueProto The protobuf Value message to convert.
-   * @param {boolean | IntegerTypeCastOptions} [wrapNumbers=false] Wrap values of integerValue type in
+   * @param {boolean | IntegerTypeCastOptions} [wrapNumbers=true] Wrap values of integerValue type in
    *     {@link Datastore#Int} objects.
    *     If a `boolean`, this will wrap values in {@link Datastore#Int} objects.
    *     If an `object`, this will return a value returned by
@@ -523,10 +523,21 @@ export namespace entity {
       }
 
       case 'doubleValue': {
+        if (wrapNumbers === undefined) {
+          wrapNumbers = true;
+        }
+
+        if (wrapNumbers) {
+          return new entity.Double(value);
+        }
         return Number(value);
       }
 
       case 'integerValue': {
+        if (wrapNumbers === undefined) {
+          wrapNumbers = true;
+        }
+
         return wrapNumbers
           ? typeof wrapNumbers === 'object'
             ? new entity.Int(valueProto, wrapNumbers).valueOf()

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -547,7 +547,7 @@ export namespace entity {
         }
 
         if (wrapNumbers) {
-          return new entity.Double(value);
+          return new entity.Double(valueProto);
         }
         return Number(value);
       }

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -596,7 +596,8 @@ export namespace entity {
         "'IntegerOutOfBoundsWarning: the value for '" +
         property +
         "' property is outside of bounds of a JavaScript Number.\n" +
-        "Use 'Datastore.int(<integer_value_as_string>)' to preserve accuracy during the upload.";
+        "Use 'Datastore.int(<integer_value_as_string>)' to preserve accuracy " +
+        'in your database.';
 
       const typeCastWarning =
         "TypeCastWarning: the value for '" +
@@ -604,7 +605,7 @@ export namespace entity {
         "' property is a JavaScript Number.\n" +
         "Use 'Datastore.int(<integer_value_as_string>)' or " +
         "'Datastore.double(<double_value_as_string>)' to preserve consistent " +
-        'Datastore types during the upload.';
+        'Datastore types in your database.';
 
       if (Number.isInteger(value)) {
         if (!Number.isSafeInteger(value)) {

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -685,7 +685,6 @@ export namespace entity {
 
   const warningTypesIssued = new Set<string>();
   const warn = (warningName: string, warningMessage: string) => {
-    console.log(warningName);
     if (!warningTypesIssued.has(warningName)) {
       warningTypesIssued.add(warningName);
       process.emitWarning(warningMessage);

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -593,7 +593,7 @@ export namespace entity {
 
     if (typeof value === 'number') {
       const integerOutOfBoundsWarning =
-        "'IntegerOutOfBoundsWarning: the value for '" +
+        "IntegerOutOfBoundsWarning: the value for '" +
         property +
         "' property is outside of bounds of a JavaScript Number.\n" +
         "Use 'Datastore.int(<integer_value_as_string>)' to preserve accuracy " +

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -62,7 +62,7 @@ export namespace entity {
   export class Double extends Number {
     private _entityPropertyName: string | undefined;
     type: string;
-    value: string;
+    value: number;
     constructor(value: number | string | ValueProto) {
       super(typeof value === 'object' ? value.doubleValue : value);
 
@@ -77,12 +77,10 @@ export namespace entity {
 
       /**
        * @name Double#value
-       * @type {string}
+       * @type {number}
        */
       this.value =
-        typeof value === 'object'
-          ? value.doubleValue.toString()
-          : value.toString();
+        typeof value === 'object' ? Number(value.doubleValue) : Number(value);
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -90,7 +88,7 @@ export namespace entity {
       return Number(this.value);
     }
 
-    toJSON(): Json {
+    toJSON(): any {
       return {type: this.type, value: this.value};
     }
   }

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -16,11 +16,11 @@
 import arrify = require('arrify');
 import * as extend from 'extend';
 import * as is from 'is';
-import { Query, QueryProto, IntegerTypeCastOptions } from './query';
-import { PathType } from '.';
-import { protobuf as Protobuf } from 'google-gax';
+import {Query, QueryProto, IntegerTypeCastOptions} from './query';
+import {PathType} from '.';
+import {protobuf as Protobuf} from 'google-gax';
 import * as path from 'path';
-import { google } from '../protos/protos';
+import {google} from '../protos/protos';
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace entity {
@@ -33,7 +33,7 @@ export namespace entity {
       const errorMessages = {
         MISSING_KIND: 'A key should contain at least a kind.',
         MISSING_ANCESTOR_ID: 'Ancestor keys require an id or name.',
-      } as { [index: string]: string };
+      } as {[index: string]: string};
       super(errorMessages[opts.code]);
       this.name = 'InvalidKey';
     }
@@ -188,7 +188,7 @@ export namespace entity {
     }
 
     toJSON(): Json {
-      return { type: this.type, value: this.value };
+      return {type: this.type, value: this.value};
     }
   }
 
@@ -446,16 +446,16 @@ export namespace entity {
     if (!Number.isSafeInteger(num)) {
       throw new Error(
         'We attempted to return all of the numeric values, but ' +
-        (value.propertyName ? value.propertyName + ' ' : '') +
-        'value ' +
-        value.integerValue +
-        " is out of bounds of 'Number.MAX_SAFE_INTEGER'.\n" +
-        "To prevent this error, please consider passing 'options.wrapNumbers=true' or\n" +
-        "'options.wrapNumbers' as\n" +
-        '{\n' +
-        '  integerTypeCastFunction: provide <your_custom_function>\n' +
-        '  properties: optionally specify property name(s) to be custom casted\n' +
-        '}\n'
+          (value.propertyName ? value.propertyName + ' ' : '') +
+          'value ' +
+          value.integerValue +
+          " is out of bounds of 'Number.MAX_SAFE_INTEGER'.\n" +
+          "To prevent this error, please consider passing 'options.wrapNumbers=true' or\n" +
+          "'options.wrapNumbers' as\n" +
+          '{\n' +
+          '  integerTypeCastFunction: provide <your_custom_function>\n' +
+          '  properties: optionally specify property name(s) to be custom casted\n' +
+          '}\n'
       );
     }
     return num;
@@ -690,7 +690,7 @@ export namespace entity {
       warningTypesIssued.add(warningName);
       process.emitWarning(warningMessage);
     }
-  }
+  };
 
   /**
    * Convert any entity protocol to a plain object.
@@ -1342,7 +1342,7 @@ export namespace entity {
       const reference = {
         app: projectId,
         namespace: key.namespace,
-        path: { element: elements },
+        path: {element: elements},
       };
 
       const buffer = this.protos.Reference.encode(reference).finish();
@@ -1439,7 +1439,7 @@ export interface ValueProto {
 
 export interface EntityProto {
   key?: KeyProto | null;
-  properties?: { [k: string]: ValueProto };
+  properties?: {[k: string]: ValueProto};
   excludeFromIndexes?: boolean;
 }
 
@@ -1463,7 +1463,7 @@ export interface ResponseResult {
 }
 
 export interface EntityObject {
-  data: { [k: string]: Entity };
+  data: {[k: string]: Entity};
   excludeFromIndexes: string[];
 }
 

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -16,12 +16,12 @@
 import arrify = require('arrify');
 import * as extend from 'extend';
 import * as is from 'is';
-import { Query, QueryProto, IntegerTypeCastOptions } from './query';
-import { PathType } from '.';
-import { protobuf as Protobuf } from 'google-gax';
+import {Query, QueryProto, IntegerTypeCastOptions} from './query';
+import {PathType} from '.';
+import {protobuf as Protobuf} from 'google-gax';
 import * as path from 'path';
-import { google } from '../protos/protos';
-import { type } from 'os';
+import {google} from '../protos/protos';
+import {type} from 'os';
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace entity {
@@ -34,7 +34,7 @@ export namespace entity {
       const errorMessages = {
         MISSING_KIND: 'A key should contain at least a kind.',
         MISSING_ANCESTOR_ID: 'Ancestor keys require an id or name.',
-      } as { [index: string]: string };
+      } as {[index: string]: string};
       super(errorMessages[opts.code]);
       this.name = 'InvalidKey';
     }
@@ -189,7 +189,7 @@ export namespace entity {
     }
 
     toJSON(): Json {
-      return { type: this.type, value: this.value };
+      return {type: this.type, value: this.value};
     }
   }
 
@@ -447,16 +447,16 @@ export namespace entity {
     if (!Number.isSafeInteger(num)) {
       throw new Error(
         'We attempted to return all of the numeric values, but ' +
-        (value.propertyName ? value.propertyName + ' ' : '') +
-        'value ' +
-        value.integerValue +
-        " is out of bounds of 'Number.MAX_SAFE_INTEGER'.\n" +
-        "To prevent this error, please consider passing 'options.wrapNumbers=true' or\n" +
-        "'options.wrapNumbers' as\n" +
-        '{\n' +
-        '  integerTypeCastFunction: provide <your_custom_function>\n' +
-        '  properties: optionally specify property name(s) to be custom casted\n' +
-        '}\n'
+          (value.propertyName ? value.propertyName + ' ' : '') +
+          'value ' +
+          value.integerValue +
+          " is out of bounds of 'Number.MAX_SAFE_INTEGER'.\n" +
+          "To prevent this error, please consider passing 'options.wrapNumbers=true' or\n" +
+          "'options.wrapNumbers' as\n" +
+          '{\n' +
+          '  integerTypeCastFunction: provide <your_custom_function>\n' +
+          '  properties: optionally specify property name(s) to be custom casted\n' +
+          '}\n'
       );
     }
     return num;
@@ -592,18 +592,19 @@ export namespace entity {
     }
 
     if (typeof value === 'number') {
-      const integerOutOfBoundsWarning = "'IntegerOutOfBoundsWarning: the value for '" +
+      const integerOutOfBoundsWarning =
+        "'IntegerOutOfBoundsWarning: the value for '" +
         property +
         "' property is outside of bounds of a JavaScript Number.\n" +
-        "Use 'Datastore.int(<integer_value_as_string>)' to preserve accuracy during the upload."
+        "Use 'Datastore.int(<integer_value_as_string>)' to preserve accuracy during the upload.";
 
-      const typeCastWarning = "TypeCastWarning: the value for '" +
+      const typeCastWarning =
+        "TypeCastWarning: the value for '" +
         property +
         "' property is a JavaScript Number.\n" +
         "Use 'Datastore.int(<integer_value_as_string>)' or " +
         "'Datastore.double(<double_value_as_string>)' to preserve consistent " +
-        "Datastore types during the upload."
-
+        'Datastore types during the upload.';
 
       if (Number.isInteger(value)) {
         if (!Number.isSafeInteger(value)) {
@@ -1332,7 +1333,7 @@ export namespace entity {
       const reference = {
         app: projectId,
         namespace: key.namespace,
-        path: { element: elements },
+        path: {element: elements},
       };
 
       const buffer = this.protos.Reference.encode(reference).finish();
@@ -1429,7 +1430,7 @@ export interface ValueProto {
 
 export interface EntityProto {
   key?: KeyProto | null;
-  properties?: { [k: string]: ValueProto };
+  properties?: {[k: string]: ValueProto};
   excludeFromIndexes?: boolean;
 }
 
@@ -1453,7 +1454,7 @@ export interface ResponseResult {
 }
 
 export interface EntityObject {
-  data: { [k: string]: Entity };
+  data: {[k: string]: Entity};
   excludeFromIndexes: string[];
 }
 

--- a/src/query.ts
+++ b/src/query.ts
@@ -400,7 +400,7 @@ class Query {
    *     [here](https://cloud.google.com/datastore/docs/articles/balancing-strong-and-eventual-consistency-with-google-cloud-datastore).
    * @param {object} [options.gaxOptions] Request configuration options, outlined
    *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
-   * @param {boolean | IntegerTypeCastOptions} [options.wrapNumbers=false]
+   * @param {boolean | IntegerTypeCastOptions} [options.wrapNumbers=True]
    *     Wrap values of integerValue type in {@link Datastore#Int} objects.
    *     If a `boolean`, this will wrap values in {@link Datastore#Int} objects.
    *     If an `object`, this will return a value returned by

--- a/src/request.ts
+++ b/src/request.ts
@@ -447,7 +447,7 @@ class DatastoreRequest {
    *     [here](https://cloud.google.com/datastore/docs/articles/balancing-strong-and-eventual-consistency-with-google-cloud-datastore).
    * @param {object} [options.gaxOptions] Request configuration options, outlined
    *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
-   * @param {boolean | IntegerTypeCastOptions} [options.wrapNumbers=false]
+   * @param {boolean | IntegerTypeCastOptions} [options.wrapNumbers=true]
    *     Wrap values of integerValue type in {@link Datastore#Int} objects.
    *     If a `boolean`, this will wrap values in {@link Datastore#Int} objects.
    *     If an `object`, this will return a value returned by

--- a/system-test/datastore.ts
+++ b/system-test/datastore.ts
@@ -276,7 +276,7 @@ describe('Datastore', () => {
       // Expect content is stored in datastore as a double with wrapping to
       // return a wrapped double
       assert.strictEqual(entity.points.type, 'DatastoreDouble');
-      assert.strictEqual(entity.points.value, 2);
+      assert.strictEqual(entity.points.value, '2');
 
       [entity] = await datastore.get(postKey, {wrapNumbers: false});
       // Verify that when requested with wrapNumbers false, we get a plain
@@ -286,7 +286,7 @@ describe('Datastore', () => {
       [entity] = await datastore.get(postKey);
       // Expect without any options, a wrapped double to be returned.
       assert.strictEqual(entity.points.type, 'DatastoreDouble');
-      assert.strictEqual(entity.points.value, 2);
+      assert.strictEqual(entity.points.value, '2');
 
       // Save the data again, reget, ensuring that along the way it isn't
       // somehow changed to another numeric type.
@@ -294,7 +294,10 @@ describe('Datastore', () => {
       [entity] = await datastore.get(postKey);
       // expect as we saved, that this property is still a DatastoreDouble.
       assert.strictEqual(entity.points.type, 'DatastoreDouble');
-      assert.strictEqual(entity.points.value, 2);
+      assert.strictEqual(entity.points.value, '2');
+
+      // Verify that DatastoreDouble implement Number behavior
+      assert.strictEqual(entity.points + 1, 3);
 
       await datastore.delete(postKey);
     });

--- a/system-test/datastore.ts
+++ b/system-test/datastore.ts
@@ -20,6 +20,7 @@ import * as yaml from 'js-yaml';
 import {Datastore, Index} from '../src';
 import {google} from '../protos/protos';
 import {Storage} from '@google-cloud/storage';
+import {entity} from '../src/entity';
 
 describe('Datastore', () => {
   const testKinds: string[] = [];
@@ -67,11 +68,11 @@ describe('Datastore', () => {
       publishedAt: new Date(),
       author: 'Silvano',
       isDraft: false,
-      wordCount: 400,
-      rating: 5.0,
+      wordCount: new entity.Int({propertyName: 'wordCount', integerValue: 400}),
+      rating: new entity.Double({propertyName: 'rating', doubleValue: 5.0}),
       likes: null,
       metadata: {
-        views: 100,
+        views: new entity.Int({propertyName: 'views', integerValue: 100}),
       },
     };
 
@@ -547,7 +548,7 @@ describe('Datastore', () => {
           },
         });
         const [entity] = await datastore.get(key);
-        assert.strictEqual(entity.year, integerValue);
+        assert.strictEqual(entity.year.valueOf(), integerValue);
       });
 
       it('should save and decode a double', async () => {
@@ -561,7 +562,7 @@ describe('Datastore', () => {
           },
         });
         const [entity] = await datastore.get(key);
-        assert.strictEqual(entity.nines, doubleValue);
+        assert.strictEqual(entity.nines.valueOf(), doubleValue);
       });
 
       it('should save and decode a geo point', async () => {
@@ -919,7 +920,7 @@ describe('Datastore', () => {
         datastore.get(key),
       ]);
       assert.strictEqual(typeof deletedEntity, 'undefined');
-      assert.strictEqual(fetchedEntity.rating, 10);
+      assert.strictEqual(fetchedEntity.rating.valueOf(), 10);
     });
 
     it('should use the last modification to a key', async () => {

--- a/system-test/datastore.ts
+++ b/system-test/datastore.ts
@@ -277,7 +277,7 @@ describe('Datastore', () => {
       // Expect content is stored in datastore as a double with wrapping to
       // return a wrapped double
       assert.strictEqual(entity.points.type, 'DatastoreDouble');
-      assert.strictEqual(entity.points.value, '2');
+      assert.strictEqual(entity.points.value, 2);
 
       [entity] = await datastore.get(postKey, {wrapNumbers: false});
       // Verify that when requested with wrapNumbers false, we get a plain
@@ -287,7 +287,7 @@ describe('Datastore', () => {
       [entity] = await datastore.get(postKey);
       // Expect without any options, a wrapped double to be returned.
       assert.strictEqual(entity.points.type, 'DatastoreDouble');
-      assert.strictEqual(entity.points.value, '2');
+      assert.strictEqual(entity.points.value, 2);
 
       // Save the data again, reget, ensuring that along the way it isn't
       // somehow changed to another numeric type.
@@ -295,7 +295,7 @@ describe('Datastore', () => {
       [entity] = await datastore.get(postKey);
       // expect as we saved, that this property is still a DatastoreDouble.
       assert.strictEqual(entity.points.type, 'DatastoreDouble');
-      assert.strictEqual(entity.points.value, '2');
+      assert.strictEqual(entity.points.value, 2);
 
       // Verify that DatastoreDouble implement Number behavior
       assert.strictEqual(entity.points + 1, 3);

--- a/system-test/datastore.ts
+++ b/system-test/datastore.ts
@@ -268,6 +268,35 @@ describe('Datastore', () => {
       await datastore.delete(postKey);
     });
 
+    it('should save/get an int-able double value via Datastore.', async () => {
+      const postKey = datastore.key('Team');
+      const points = Datastore.double(2);
+      await datastore.save({key: postKey, data: {points}});
+      let [entity] = await datastore.get(postKey, {wrapNumbers: true});
+      // Expect content is stored in datastore as a double, returned as int
+      // as doubles can safely be brought to local types.
+      // NOTE: this is a bit awkward as is since you can't prevent decoding of doubles
+      // assert.strictEqual(entity.points.type, 'DatastoreDouble');
+      // assert.strictEqual(entity.points.value, '2');
+      assert.strictEqual(entity.points, 2);
+
+      [entity] = await datastore.get(postKey);
+      // without wrap numbers, expect to get a number '2'
+      assert.strictEqual(entity.points, 2);
+
+      // If we re-save here, without numbers wrapped, it will raise a warning
+      // we have an unsafe to convert representation
+      // NOTE: the data has been reuploaded in a different state than what was
+      // retrieved
+      await datastore.save(entity);
+      [entity] = await datastore.get(postKey, {wrapNumbers: true});
+      // expect as we saved, that this has been made into a a datastore int now.
+      assert.strictEqual(entity.points.type, 'DatastoreInt');
+      assert.strictEqual(entity.points.value, '2');
+
+      await datastore.delete(postKey);
+    });
+
     it('should wrap specified properties via IntegerTypeCastOptions.properties', async () => {
       const postKey = datastore.key('Scores');
       const largeIntValueAsString = '9223372036854775807';

--- a/system-test/datastore.ts
+++ b/system-test/datastore.ts
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 import * as assert from 'assert';
-import {readFileSync} from 'fs';
+import { readFileSync } from 'fs';
 import * as path from 'path';
-import {before, after, describe, it} from 'mocha';
+import { before, after, describe, it } from 'mocha';
 import * as yaml from 'js-yaml';
-import {Datastore, Index} from '../src';
-import {google} from '../protos/protos';
-import {Storage} from '@google-cloud/storage';
+import { Datastore, Index } from '../src';
+import { google } from '../protos/protos';
+import { Storage } from '@google-cloud/storage';
 
 describe('Datastore', () => {
   const testKinds: string[] = [];
@@ -36,9 +36,9 @@ describe('Datastore', () => {
     return keyObject;
   };
 
-  const {indexes: DECLARED_INDEXES} = yaml.safeLoad(
+  const { indexes: DECLARED_INDEXES } = yaml.safeLoad(
     readFileSync(path.join(__dirname, 'data', 'index.yaml'), 'utf8')
-  ) as {indexes: google.datastore.admin.v1.IIndex[]};
+  ) as { indexes: google.datastore.admin.v1.IIndex[] };
 
   // TODO/DX ensure indexes before testing, and maybe? cleanup indexes after
   //  possible implications with kokoro project
@@ -67,11 +67,11 @@ describe('Datastore', () => {
       publishedAt: new Date(),
       author: 'Silvano',
       isDraft: false,
-      wordCount: 400,
-      rating: 5.0,
+      wordCount: datastore.int(400),
+      rating: datastore.double(5.0),
       likes: null,
       metadata: {
-        views: 100,
+        views: datastore.int(100),
       },
     };
 
@@ -261,8 +261,8 @@ describe('Datastore', () => {
       const postKey = datastore.key('Team');
       const largeIntValueAsString = '9223372036854775807';
       const points = Datastore.int(largeIntValueAsString);
-      await datastore.save({key: postKey, data: {points}});
-      const [entity] = await datastore.get(postKey, {wrapNumbers: true});
+      await datastore.save({ key: postKey, data: { points } });
+      const [entity] = await datastore.get(postKey, { wrapNumbers: true });
       assert.strictEqual(entity.points.value, largeIntValueAsString);
       assert.throws(() => entity.points.valueOf());
       await datastore.delete(postKey);
@@ -272,9 +272,9 @@ describe('Datastore', () => {
       const postKey = datastore.key('Scores');
       const largeIntValueAsString = '9223372036854775807';
       const panthers = Datastore.int(largeIntValueAsString);
-      const broncos = 922337203;
+      const broncos = Datastore.int(922337203);
       let integerTypeCastFunctionCalled = 0;
-      await datastore.save({key: postKey, data: {panthers, broncos}});
+      await datastore.save({ key: postKey, data: { panthers, broncos } });
       const [entity] = await datastore.get(postKey, {
         wrapNumbers: {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -295,7 +295,7 @@ describe('Datastore', () => {
 
     it('should save/get/delete with a key name', async () => {
       const postKey = datastore.key(['Post', 'post1']);
-      await datastore.save({key: postKey, data: post});
+      await datastore.save({ key: postKey, data: post });
       const [entity] = await datastore.get(postKey);
       assert.deepStrictEqual(entity[datastore.KEY], postKey);
       delete entity[datastore.KEY];
@@ -305,7 +305,7 @@ describe('Datastore', () => {
 
     it('should save/get/delete with a numeric key id', async () => {
       const postKey = datastore.key(['Post', 123456789]);
-      await datastore.save({key: postKey, data: post});
+      await datastore.save({ key: postKey, data: post });
       const [entity] = await datastore.get(postKey);
       delete entity[datastore.KEY];
       assert.deepStrictEqual(entity, post);
@@ -317,7 +317,7 @@ describe('Datastore', () => {
       const data = {
         buf: Buffer.from('010100000000000000000059400000000000006940', 'hex'),
       };
-      await datastore.save({key: postKey, data});
+      await datastore.save({ key: postKey, data });
       const assignedId = postKey.id;
       assert(assignedId);
       const [entity] = await datastore.get(postKey);
@@ -331,7 +331,7 @@ describe('Datastore', () => {
       const data = {
         buf: Buffer.from([]),
       };
-      await datastore.save({key: postKey, data});
+      await datastore.save({ key: postKey, data });
       const assignedId = postKey.id;
       assert(assignedId);
       const [entity] = await datastore.get(postKey);
@@ -342,7 +342,7 @@ describe('Datastore', () => {
 
     it('should save/get/delete with a generated key id', async () => {
       const postKey = datastore.key('Post');
-      await datastore.save({key: postKey, data: post});
+      await datastore.save({ key: postKey, data: post });
 
       // The key's path should now be complete.
       assert(postKey.id);
@@ -355,7 +355,7 @@ describe('Datastore', () => {
 
     it('should save/get/update', async () => {
       const postKey = datastore.key('Post');
-      await datastore.save({key: postKey, data: post});
+      await datastore.save({ key: postKey, data: post });
       const [entity] = await datastore.get(postKey);
       assert.strictEqual(entity.title, post.title);
       entity.title = 'Updated';
@@ -405,7 +405,7 @@ describe('Datastore', () => {
 
     it('should fail explicitly set second insert on save', async () => {
       const postKey = datastore.key('Post');
-      await datastore.save({key: postKey, data: post});
+      await datastore.save({ key: postKey, data: post });
 
       // The key's path should now be complete.
       assert(postKey.id);
@@ -440,14 +440,14 @@ describe('Datastore', () => {
         publishedAt: new Date('2001-01-01T00:00:00.000Z'),
         author: 'Silvano',
         isDraft: false,
-        wordCount: 450,
-        rating: 4.5,
+        wordCount: datastore.int(450),
+        rating: datastore.double(4.5),
       };
       const key1 = datastore.key('Post');
       const key2 = datastore.key('Post');
       await datastore.save([
-        {key: key1, data: post},
-        {key: key2, data: post2},
+        { key: key1, data: post },
+        { key: key2, data: post2 },
       ]);
       const [entities] = await datastore.get([key1, key2]);
       assert.strictEqual(entities.length, 2);
@@ -460,8 +460,8 @@ describe('Datastore', () => {
 
       datastore.save(
         [
-          {key: key1, data: post},
-          {key: key2, data: post},
+          { key: key1, data: post },
+          { key: key2, data: post },
         ],
         err => {
           assert.ifError(err);
@@ -570,49 +570,49 @@ describe('Datastore', () => {
       {
         name: 'Rickard',
         family: 'Stark',
-        appearances: 9,
+        appearances: datastore.int(9),
         alive: false,
       },
       {
         name: 'Eddard',
         family: 'Stark',
-        appearances: 9,
+        appearances: datastore.int(9),
         alive: false,
       },
       {
         name: 'Catelyn',
         family: ['Stark', 'Tully'],
-        appearances: 26,
+        appearances: datastore.int(26),
         alive: false,
       },
       {
         name: 'Arya',
         family: 'Stark',
-        appearances: 33,
+        appearances: datastore.int(33),
         alive: true,
       },
       {
         name: 'Sansa',
         family: 'Stark',
-        appearances: 31,
+        appearances: datastore.int(31),
         alive: true,
       },
       {
         name: 'Robb',
         family: 'Stark',
-        appearances: 22,
+        appearances: datastore.int(22),
         alive: false,
       },
       {
         name: 'Bran',
         family: 'Stark',
-        appearances: 25,
+        appearances: datastore.int(25),
         alive: true,
       },
       {
         name: 'Jon Snow',
         family: 'Stark',
-        appearances: 32,
+        appearances: datastore.int(32),
         alive: true,
       },
     ];
@@ -715,7 +715,7 @@ describe('Datastore', () => {
       const q = datastore
         .createQuery('Character')
         .hasAncestor(ancestor)
-        .filter('appearances', '>=', 20);
+        .filter('appearances', '>=', datastore.int(20));
       const [entities] = await datastore.runQuery(q);
       assert.strictEqual(entities!.length, 6);
     });
@@ -725,7 +725,7 @@ describe('Datastore', () => {
         .createQuery('Character')
         .hasAncestor(ancestor)
         .filter('family', 'Stark')
-        .filter('appearances', '>=', 20);
+        .filter('appearances', '>=', datastore.int(20));
       const [entities] = await datastore.runQuery(q);
       assert.strictEqual(entities!.length, 6);
     });
@@ -841,7 +841,7 @@ describe('Datastore', () => {
       const transaction = datastore.transaction();
       await transaction.run();
       await transaction.get(key);
-      transaction.save({key, data: obj});
+      transaction.save({ key, data: obj });
       await transaction.commit();
       const [entity] = await datastore.get(key);
       delete entity[datastore.KEY];
@@ -865,11 +865,11 @@ describe('Datastore', () => {
       transaction.save([
         {
           key,
-          data: {rating: 10},
+          data: { rating: datastore.int(10) },
         },
         {
           key: incompleteKey,
-          data: {rating: 100},
+          data: { rating: datastore.int(100) },
         },
       ]);
 
@@ -885,7 +885,7 @@ describe('Datastore', () => {
         datastore.get(key),
       ]);
       assert.strictEqual(typeof deletedEntity, 'undefined');
-      assert.strictEqual(fetchedEntity.rating, 10);
+      assert.strictEqual(fetchedEntity.rating, datastore.int(10));
     });
 
     it('should use the last modification to a key', async () => {
@@ -897,13 +897,13 @@ describe('Datastore', () => {
         {
           key,
           data: {
-            rating: 10,
+            rating: datastore.int(10),
           },
         },
         {
           key: incompleteKey,
           data: {
-            rating: 100,
+            rating: datastore.int(100),
           },
         },
       ]);
@@ -934,18 +934,18 @@ describe('Datastore', () => {
     });
 
     it('should read in a readOnly transaction', async () => {
-      const transaction = datastore.transaction({readOnly: true});
+      const transaction = datastore.transaction({ readOnly: true });
       const key = datastore.key(['Company', 'Google']);
       await transaction.run();
       await transaction.get(key);
     });
 
     it('should not write in a readOnly transaction', async () => {
-      const transaction = datastore.transaction({readOnly: true});
+      const transaction = datastore.transaction({ readOnly: true });
       const key = datastore.key(['Company', 'Google']);
       await transaction.run();
       await transaction.get(key);
-      transaction.save({key, data: {}});
+      transaction.save({ key, data: {} });
       await assert.rejects(transaction.commit());
     });
   });
@@ -1008,10 +1008,10 @@ describe('Datastore', () => {
     const bucket = gcs.bucket('nodejs-datastore-system-tests');
 
     it('should export, then import entities', async () => {
-      const [exportOperation] = await datastore.export({bucket});
+      const [exportOperation] = await datastore.export({ bucket });
       await exportOperation.promise();
 
-      const [files] = await bucket.getFiles({maxResults: 1});
+      const [files] = await bucket.getFiles({ maxResults: 1 });
       const [exportedFile] = files;
       assert.ok(exportedFile.name.includes('overall_export_metadata'));
 

--- a/system-test/datastore.ts
+++ b/system-test/datastore.ts
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 import * as assert from 'assert';
-import { readFileSync } from 'fs';
+import {readFileSync} from 'fs';
 import * as path from 'path';
-import { before, after, describe, it } from 'mocha';
+import {before, after, describe, it} from 'mocha';
 import * as yaml from 'js-yaml';
-import { Datastore, Index } from '../src';
-import { google } from '../protos/protos';
-import { Storage } from '@google-cloud/storage';
+import {Datastore, Index} from '../src';
+import {google} from '../protos/protos';
+import {Storage} from '@google-cloud/storage';
 
 describe('Datastore', () => {
   const testKinds: string[] = [];
@@ -36,9 +36,9 @@ describe('Datastore', () => {
     return keyObject;
   };
 
-  const { indexes: DECLARED_INDEXES } = yaml.safeLoad(
+  const {indexes: DECLARED_INDEXES} = yaml.safeLoad(
     readFileSync(path.join(__dirname, 'data', 'index.yaml'), 'utf8')
-  ) as { indexes: google.datastore.admin.v1.IIndex[] };
+  ) as {indexes: google.datastore.admin.v1.IIndex[]};
 
   // TODO/DX ensure indexes before testing, and maybe? cleanup indexes after
   //  possible implications with kokoro project
@@ -67,11 +67,11 @@ describe('Datastore', () => {
       publishedAt: new Date(),
       author: 'Silvano',
       isDraft: false,
-      wordCount: datastore.int(400),
-      rating: datastore.double(5.0),
+      wordCount: 400,
+      rating: 5.0,
       likes: null,
       metadata: {
-        views: datastore.int(100),
+        views: 100,
       },
     };
 
@@ -261,8 +261,8 @@ describe('Datastore', () => {
       const postKey = datastore.key('Team');
       const largeIntValueAsString = '9223372036854775807';
       const points = Datastore.int(largeIntValueAsString);
-      await datastore.save({ key: postKey, data: { points } });
-      const [entity] = await datastore.get(postKey, { wrapNumbers: true });
+      await datastore.save({key: postKey, data: {points}});
+      const [entity] = await datastore.get(postKey, {wrapNumbers: true});
       assert.strictEqual(entity.points.value, largeIntValueAsString);
       assert.throws(() => entity.points.valueOf());
       await datastore.delete(postKey);
@@ -272,9 +272,9 @@ describe('Datastore', () => {
       const postKey = datastore.key('Scores');
       const largeIntValueAsString = '9223372036854775807';
       const panthers = Datastore.int(largeIntValueAsString);
-      const broncos = Datastore.int(922337203);
+      const broncos = 922337203;
       let integerTypeCastFunctionCalled = 0;
-      await datastore.save({ key: postKey, data: { panthers, broncos } });
+      await datastore.save({key: postKey, data: {panthers, broncos}});
       const [entity] = await datastore.get(postKey, {
         wrapNumbers: {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -295,7 +295,7 @@ describe('Datastore', () => {
 
     it('should save/get/delete with a key name', async () => {
       const postKey = datastore.key(['Post', 'post1']);
-      await datastore.save({ key: postKey, data: post });
+      await datastore.save({key: postKey, data: post});
       const [entity] = await datastore.get(postKey);
       assert.deepStrictEqual(entity[datastore.KEY], postKey);
       delete entity[datastore.KEY];
@@ -305,7 +305,7 @@ describe('Datastore', () => {
 
     it('should save/get/delete with a numeric key id', async () => {
       const postKey = datastore.key(['Post', 123456789]);
-      await datastore.save({ key: postKey, data: post });
+      await datastore.save({key: postKey, data: post});
       const [entity] = await datastore.get(postKey);
       delete entity[datastore.KEY];
       assert.deepStrictEqual(entity, post);
@@ -317,7 +317,7 @@ describe('Datastore', () => {
       const data = {
         buf: Buffer.from('010100000000000000000059400000000000006940', 'hex'),
       };
-      await datastore.save({ key: postKey, data });
+      await datastore.save({key: postKey, data});
       const assignedId = postKey.id;
       assert(assignedId);
       const [entity] = await datastore.get(postKey);
@@ -331,7 +331,7 @@ describe('Datastore', () => {
       const data = {
         buf: Buffer.from([]),
       };
-      await datastore.save({ key: postKey, data });
+      await datastore.save({key: postKey, data});
       const assignedId = postKey.id;
       assert(assignedId);
       const [entity] = await datastore.get(postKey);
@@ -342,7 +342,7 @@ describe('Datastore', () => {
 
     it('should save/get/delete with a generated key id', async () => {
       const postKey = datastore.key('Post');
-      await datastore.save({ key: postKey, data: post });
+      await datastore.save({key: postKey, data: post});
 
       // The key's path should now be complete.
       assert(postKey.id);
@@ -355,7 +355,7 @@ describe('Datastore', () => {
 
     it('should save/get/update', async () => {
       const postKey = datastore.key('Post');
-      await datastore.save({ key: postKey, data: post });
+      await datastore.save({key: postKey, data: post});
       const [entity] = await datastore.get(postKey);
       assert.strictEqual(entity.title, post.title);
       entity.title = 'Updated';
@@ -405,7 +405,7 @@ describe('Datastore', () => {
 
     it('should fail explicitly set second insert on save', async () => {
       const postKey = datastore.key('Post');
-      await datastore.save({ key: postKey, data: post });
+      await datastore.save({key: postKey, data: post});
 
       // The key's path should now be complete.
       assert(postKey.id);
@@ -440,14 +440,14 @@ describe('Datastore', () => {
         publishedAt: new Date('2001-01-01T00:00:00.000Z'),
         author: 'Silvano',
         isDraft: false,
-        wordCount: datastore.int(450),
-        rating: datastore.double(4.5),
+        wordCount: 450,
+        rating: 4.5,
       };
       const key1 = datastore.key('Post');
       const key2 = datastore.key('Post');
       await datastore.save([
-        { key: key1, data: post },
-        { key: key2, data: post2 },
+        {key: key1, data: post},
+        {key: key2, data: post2},
       ]);
       const [entities] = await datastore.get([key1, key2]);
       assert.strictEqual(entities.length, 2);
@@ -460,8 +460,8 @@ describe('Datastore', () => {
 
       datastore.save(
         [
-          { key: key1, data: post },
-          { key: key2, data: post },
+          {key: key1, data: post},
+          {key: key2, data: post},
         ],
         err => {
           assert.ifError(err);
@@ -570,49 +570,49 @@ describe('Datastore', () => {
       {
         name: 'Rickard',
         family: 'Stark',
-        appearances: datastore.int(9),
+        appearances: 9,
         alive: false,
       },
       {
         name: 'Eddard',
         family: 'Stark',
-        appearances: datastore.int(9),
+        appearances: 9,
         alive: false,
       },
       {
         name: 'Catelyn',
         family: ['Stark', 'Tully'],
-        appearances: datastore.int(26),
+        appearances: 26,
         alive: false,
       },
       {
         name: 'Arya',
         family: 'Stark',
-        appearances: datastore.int(33),
+        appearances: 33,
         alive: true,
       },
       {
         name: 'Sansa',
         family: 'Stark',
-        appearances: datastore.int(31),
+        appearances: 31,
         alive: true,
       },
       {
         name: 'Robb',
         family: 'Stark',
-        appearances: datastore.int(22),
+        appearances: 22,
         alive: false,
       },
       {
         name: 'Bran',
         family: 'Stark',
-        appearances: datastore.int(25),
+        appearances: 25,
         alive: true,
       },
       {
         name: 'Jon Snow',
         family: 'Stark',
-        appearances: datastore.int(32),
+        appearances: 32,
         alive: true,
       },
     ];
@@ -715,7 +715,7 @@ describe('Datastore', () => {
       const q = datastore
         .createQuery('Character')
         .hasAncestor(ancestor)
-        .filter('appearances', '>=', datastore.int(20));
+        .filter('appearances', '>=', 20);
       const [entities] = await datastore.runQuery(q);
       assert.strictEqual(entities!.length, 6);
     });
@@ -725,7 +725,7 @@ describe('Datastore', () => {
         .createQuery('Character')
         .hasAncestor(ancestor)
         .filter('family', 'Stark')
-        .filter('appearances', '>=', datastore.int(20));
+        .filter('appearances', '>=', 20);
       const [entities] = await datastore.runQuery(q);
       assert.strictEqual(entities!.length, 6);
     });
@@ -841,7 +841,7 @@ describe('Datastore', () => {
       const transaction = datastore.transaction();
       await transaction.run();
       await transaction.get(key);
-      transaction.save({ key, data: obj });
+      transaction.save({key, data: obj});
       await transaction.commit();
       const [entity] = await datastore.get(key);
       delete entity[datastore.KEY];
@@ -865,11 +865,11 @@ describe('Datastore', () => {
       transaction.save([
         {
           key,
-          data: { rating: datastore.int(10) },
+          data: {rating: 10},
         },
         {
           key: incompleteKey,
-          data: { rating: datastore.int(100) },
+          data: {rating: 100},
         },
       ]);
 
@@ -885,7 +885,7 @@ describe('Datastore', () => {
         datastore.get(key),
       ]);
       assert.strictEqual(typeof deletedEntity, 'undefined');
-      assert.strictEqual(fetchedEntity.rating, datastore.int(10));
+      assert.strictEqual(fetchedEntity.rating, 10);
     });
 
     it('should use the last modification to a key', async () => {
@@ -897,13 +897,13 @@ describe('Datastore', () => {
         {
           key,
           data: {
-            rating: datastore.int(10),
+            rating: 10,
           },
         },
         {
           key: incompleteKey,
           data: {
-            rating: datastore.int(100),
+            rating: 100,
           },
         },
       ]);
@@ -934,18 +934,18 @@ describe('Datastore', () => {
     });
 
     it('should read in a readOnly transaction', async () => {
-      const transaction = datastore.transaction({ readOnly: true });
+      const transaction = datastore.transaction({readOnly: true});
       const key = datastore.key(['Company', 'Google']);
       await transaction.run();
       await transaction.get(key);
     });
 
     it('should not write in a readOnly transaction', async () => {
-      const transaction = datastore.transaction({ readOnly: true });
+      const transaction = datastore.transaction({readOnly: true});
       const key = datastore.key(['Company', 'Google']);
       await transaction.run();
       await transaction.get(key);
-      transaction.save({ key, data: {} });
+      transaction.save({key, data: {}});
       await assert.rejects(transaction.commit());
     });
   });
@@ -1008,10 +1008,10 @@ describe('Datastore', () => {
     const bucket = gcs.bucket('nodejs-datastore-system-tests');
 
     it('should export, then import entities', async () => {
-      const [exportOperation] = await datastore.export({ bucket });
+      const [exportOperation] = await datastore.export({bucket});
       await exportOperation.promise();
 
-      const [files] = await bucket.getFiles({ maxResults: 1 });
+      const [files] = await bucket.getFiles({maxResults: 1});
       const [exportedFile] = files;
       assert.ok(exportedFile.name.includes('overall_export_metadata'));
 

--- a/system-test/datastore.ts
+++ b/system-test/datastore.ts
@@ -273,26 +273,28 @@ describe('Datastore', () => {
       const points = Datastore.double(2);
       await datastore.save({key: postKey, data: {points}});
       let [entity] = await datastore.get(postKey, {wrapNumbers: true});
-      // Expect content is stored in datastore as a double, returned as int
-      // as doubles can safely be brought to local types.
-      // NOTE: this is a bit awkward as is since you can't prevent decoding of doubles
-      // assert.strictEqual(entity.points.type, 'DatastoreDouble');
-      // assert.strictEqual(entity.points.value, '2');
+      // Expect content is stored in datastore as a double with wrapping to
+      // return a wrapped double
+      assert.strictEqual(entity.points.type, 'DatastoreDouble');
+      assert.strictEqual(entity.points.value, 2);
+
+      [entity] = await datastore.get(postKey, {wrapNumbers: false});
+      // Verify that when requested with wrapNumbers false, we get a plain
+      // javascript Number 2.
       assert.strictEqual(entity.points, 2);
 
       [entity] = await datastore.get(postKey);
-      // without wrap numbers, expect to get a number '2'
-      assert.strictEqual(entity.points, 2);
+      // Expect without any options, a wrapped double to be returned.
+      assert.strictEqual(entity.points.type, 'DatastoreDouble');
+      assert.strictEqual(entity.points.value, 2);
 
-      // If we re-save here, without numbers wrapped, it will raise a warning
-      // we have an unsafe to convert representation
-      // NOTE: the data has been reuploaded in a different state than what was
-      // retrieved
+      // Save the data again, reget, ensuring that along the way it isn't
+      // somehow changed to another numeric type.
       await datastore.save(entity);
-      [entity] = await datastore.get(postKey, {wrapNumbers: true});
-      // expect as we saved, that this has been made into a a datastore int now.
-      assert.strictEqual(entity.points.type, 'DatastoreInt');
-      assert.strictEqual(entity.points.value, '2');
+      [entity] = await datastore.get(postKey);
+      // expect as we saved, that this property is still a DatastoreDouble.
+      assert.strictEqual(entity.points.type, 'DatastoreDouble');
+      assert.strictEqual(entity.points.value, 2);
 
       await datastore.delete(postKey);
     });

--- a/test/entity.ts
+++ b/test/entity.ts
@@ -13,12 +13,12 @@
 // limitations under the License.
 
 import * as assert from 'assert';
-import { beforeEach, afterEach, describe, it } from 'mocha';
+import {beforeEach, afterEach, describe, it} from 'mocha';
 import * as extend from 'extend';
 import * as sinon from 'sinon';
-import { Datastore } from '../src';
-import { Entity } from '../src/entity';
-import { IntegerTypeCastOptions } from '../src/query';
+import {Datastore} from '../src';
+import {Entity} from '../src/entity';
+import {IntegerTypeCastOptions} from '../src/query';
 
 export function outOfBoundsError(opts: {
   propertyName?: string;
@@ -26,16 +26,16 @@ export function outOfBoundsError(opts: {
 }) {
   return new Error(
     'We attempted to return all of the numeric values, but ' +
-    (opts.propertyName ? opts.propertyName + ' ' : '') +
-    'value ' +
-    opts.integerValue +
-    " is out of bounds of 'Number.MAX_SAFE_INTEGER'.\n" +
-    "To prevent this error, please consider passing 'options.wrapNumbers=true' or\n" +
-    "'options.wrapNumbers' as\n" +
-    '{\n' +
-    '  integerTypeCastFunction: provide <your_custom_function>\n' +
-    '  properties: optionally specify property name(s) to be custom casted\n' +
-    '}\n'
+      (opts.propertyName ? opts.propertyName + ' ' : '') +
+      'value ' +
+      opts.integerValue +
+      " is out of bounds of 'Number.MAX_SAFE_INTEGER'.\n" +
+      "To prevent this error, please consider passing 'options.wrapNumbers=true' or\n" +
+      "'options.wrapNumbers' as\n" +
+      '{\n' +
+      '  integerTypeCastFunction: provide <your_custom_function>\n' +
+      '  properties: optionally specify property name(s) to be custom casted\n' +
+      '}\n'
   );
 }
 
@@ -156,12 +156,12 @@ describe('entity', () => {
           // should throw when Number is passed
           assert.throws(() => {
             new entity.Int(largeIntegerValue).valueOf();
-          }, outOfBoundsError({ integerValue: largeIntegerValue }));
+          }, outOfBoundsError({integerValue: largeIntegerValue}));
 
           // should throw when string is passed
           assert.throws(() => {
             new entity.Int(smallIntegerValue.toString()).valueOf();
-          }, outOfBoundsError({ integerValue: smallIntegerValue }));
+          }, outOfBoundsError({integerValue: smallIntegerValue}));
         });
 
         it('should not auto throw on initialization', () => {
@@ -272,12 +272,12 @@ describe('entity', () => {
 
   describe('isDsGeoPoint', () => {
     it('should correctly identify a GeoPoint', () => {
-      const geoPoint = new entity.GeoPoint({ latitude: 24, longitude: 88 });
+      const geoPoint = new entity.GeoPoint({latitude: 24, longitude: 88});
       assert.strictEqual(entity.isDsGeoPoint(geoPoint), true);
     });
 
     it('should correctly identify a homomorphic non-GeoPoint', () => {
-      const geoPoint = new entity.GeoPoint({ latitude: 24, longitude: 88 });
+      const geoPoint = new entity.GeoPoint({latitude: 24, longitude: 88});
       const nonGeoPoint = Object.assign({}, geoPoint);
       assert.strictEqual(entity.isDsGeoPoint(nonGeoPoint), false);
     });
@@ -286,47 +286,47 @@ describe('entity', () => {
   describe('Key', () => {
     it('should assign the namespace', () => {
       const namespace = 'NS';
-      const key = new entity.Key({ namespace, path: [] });
+      const key = new entity.Key({namespace, path: []});
       assert.strictEqual(key.namespace, namespace);
     });
 
     it('should assign the kind', () => {
       const kind = 'kind';
-      const key = new entity.Key({ path: [kind] });
+      const key = new entity.Key({path: [kind]});
       assert.strictEqual(key.kind, kind);
     });
 
     it('should assign the ID', () => {
       const id = 11;
-      const key = new entity.Key({ path: ['Kind', id] });
+      const key = new entity.Key({path: ['Kind', id]});
       assert.strictEqual(key.id, id);
     });
 
     it('should assign the ID from an Int', () => {
       const id = new entity.Int(11);
-      const key = new entity.Key({ path: ['Kind', id] });
+      const key = new entity.Key({path: ['Kind', id]});
       assert.strictEqual(key.id, id.value);
     });
 
     it('should assign the name', () => {
       const name = 'name';
-      const key = new entity.Key({ path: ['Kind', name] });
+      const key = new entity.Key({path: ['Kind', name]});
       assert.strictEqual(key.name, name);
     });
 
     it('should assign a parent', () => {
-      const key = new entity.Key({ path: ['ParentKind', 1, 'Kind', 1] });
+      const key = new entity.Key({path: ['ParentKind', 1, 'Kind', 1]});
       assert(key.parent instanceof entity.Key);
     });
 
     it('should not modify input path', () => {
       const inputPath = ['ParentKind', 1, 'Kind', 1];
-      new entity.Key({ path: inputPath });
+      new entity.Key({path: inputPath});
       assert.deepStrictEqual(inputPath, ['ParentKind', 1, 'Kind', 1]);
     });
 
     it('should always compute the correct path', () => {
-      const key = new entity.Key({ path: ['ParentKind', 1, 'Kind', 1] });
+      const key = new entity.Key({path: ['ParentKind', 1, 'Kind', 1]});
       assert.deepStrictEqual(key.path, ['ParentKind', 1, 'Kind', 1]);
 
       key.parent.kind = 'GrandParentKind';
@@ -373,12 +373,12 @@ describe('entity', () => {
 
   describe('isDsKey', () => {
     it('should correctly identify a Key', () => {
-      const key = new entity.Key({ path: ['Kind', 1] });
+      const key = new entity.Key({path: ['Kind', 1]});
       assert.strictEqual(entity.isDsKey(key), true);
     });
 
     it('should correctly identify a homomorphic non-Key', () => {
-      const notKey = Object.assign({}, new entity.Key({ path: ['Kind', 1] }));
+      const notKey = Object.assign({}, new entity.Key({path: ['Kind', 1]}));
       assert.strictEqual(entity.isDsKey(notKey), false);
     });
   });
@@ -594,7 +594,7 @@ describe('entity', () => {
         });
 
         it('should wrap ints with wrapNumbers as object', () => {
-          const wrapNumbers = { integerTypeCastFunction: () => { } };
+          const wrapNumbers = {integerTypeCastFunction: () => {}};
           const stub = sinon.spy(entity, 'Int');
 
           entity.decodeValueProto(valueProto, wrapNumbers);
@@ -602,11 +602,11 @@ describe('entity', () => {
         });
 
         it('should call #valueOf if integerTypeCastFunction is provided', () => {
-          Object.assign(valueProto, { integerValue: Number.MAX_SAFE_INTEGER });
+          Object.assign(valueProto, {integerValue: Number.MAX_SAFE_INTEGER});
           const takeFirstTen = sinon
             .stub()
             .callsFake((value: string) => value.toString().substr(0, 10));
-          const wrapNumbers = { integerTypeCastFunction: takeFirstTen };
+          const wrapNumbers = {integerTypeCastFunction: takeFirstTen};
 
           assert.strictEqual(
             entity.decodeValueProto(valueProto, wrapNumbers),
@@ -751,13 +751,14 @@ describe('entity', () => {
         integerValue: value,
       };
 
-      const property = "value"
-      const expectedWarning = "TypeCastWarning: the value for '" +
+      const property = 'value';
+      const expectedWarning =
+        "TypeCastWarning: the value for '" +
         property +
         "' property is a JavaScript Number.\n" +
         "Use 'Datastore.int(<integer_value_as_string>)' or " +
         "'Datastore.double(<double_value_as_string>)' to preserve consistent " +
-        "Datastore types during the upload."
+        'Datastore types during the upload.';
       process.on('warning', warning => {
         assert.strictEqual(warning.message, expectedWarning);
         done();
@@ -805,13 +806,14 @@ describe('entity', () => {
         doubleValue: value,
       };
 
-      const property = "value"
-      const expectedWarning = "TypeCastWarning: the value for '" +
+      const property = 'value';
+      const expectedWarning =
+        "TypeCastWarning: the value for '" +
         property +
         "' property is a JavaScript Number.\n" +
         "Use 'Datastore.int(<integer_value_as_string>)' or " +
         "'Datastore.double(<double_value_as_string>)' to preserve consistent " +
-        "Datastore types during the upload."
+        'Datastore types during the upload.';
 
       process.on('warning', warning => {
         assert.strictEqual(warning.message, expectedWarning);
@@ -1010,7 +1012,7 @@ describe('entity', () => {
     });
 
     describe('should pass `wrapNumbers` to decodeValueProto', () => {
-      const entityProto = { properties: { number: {} } };
+      const entityProto = {properties: {number: {}}};
       let decodeValueProtoStub: sinon.SinonStub;
       let wrapNumbers: boolean | IntegerTypeCastOptions | undefined;
 
@@ -1042,7 +1044,7 @@ describe('entity', () => {
 
       it('should pass `wrapNumbers` to decodeValueProto as IntegerTypeCastOptions', () => {
         const integerTypeCastOptions = {
-          integerTypeCastFunction: () => { },
+          integerTypeCastFunction: () => {},
           properties: 'that',
         };
 
@@ -1176,7 +1178,7 @@ describe('entity', () => {
 
           nestedArrayVariants: [
             {
-              a: [{ b: value13 }, { c: value14 }],
+              a: [{b: value13}, {c: value14}],
             },
             {
               a: null,
@@ -1185,7 +1187,7 @@ describe('entity', () => {
               a: [value15],
             },
             {
-              a: [{ b: ['nasty', 'array'] }],
+              a: [{b: ['nasty', 'array']}],
             },
           ],
 
@@ -1540,7 +1542,7 @@ describe('entity', () => {
     });
 
     describe('should pass `wrapNumbers` to entityFromEntityProto', () => {
-      const results = [{ entity: {} }];
+      const results = [{entity: {}}];
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       let entityFromEntityProtoStub: any;
       let wrapNumbers: boolean | IntegerTypeCastOptions | undefined;
@@ -1570,7 +1572,7 @@ describe('entity', () => {
 
       it('should pass `wrapNumbers` to entityFromEntityProto as IntegerTypeCastOptions', () => {
         const integerTypeCastOptions = {
-          integerTypeCastFunction: () => { },
+          integerTypeCastFunction: () => {},
           properties: 'that',
         };
 
@@ -1890,7 +1892,7 @@ describe('entity', () => {
         path: ['Kind2', 'somename'],
       });
 
-      const ds = new Datastore({ projectId: 'project-id' });
+      const ds = new Datastore({projectId: 'project-id'});
 
       const query = ds
         .createQuery('Kind1')
@@ -1908,7 +1910,7 @@ describe('entity', () => {
     });
 
     it('should handle buffer start and end values', () => {
-      const ds = new Datastore({ projectId: 'project-id' });
+      const ds = new Datastore({projectId: 'project-id'});
       const startVal = Buffer.from('start');
       const endVal = Buffer.from('end');
 

--- a/test/entity.ts
+++ b/test/entity.ts
@@ -744,21 +744,21 @@ describe('entity', () => {
       assert.deepStrictEqual(entity.encodeValue(value), expectedValueProto);
     });
 
-    it('should encode an int', done => {
+    it.only('should encode an int', done => {
       const value = 8;
 
       const expectedValueProto = {
         integerValue: value,
       };
 
-      const property = 'value';
+      const property = 'undefined';
       const expectedWarning =
         "TypeCastWarning: the value for '" +
         property +
         "' property is a JavaScript Number.\n" +
         "Use 'Datastore.int(<integer_value_as_string>)' or " +
         "'Datastore.double(<double_value_as_string>)' to preserve consistent " +
-        'Datastore types during the upload.';
+        'Datastore types in your database.';
       process.on('warning', warning => {
         assert.strictEqual(warning.message, expectedWarning);
         done();
@@ -780,7 +780,8 @@ describe('entity', () => {
         "the value for '" +
         property +
         "' property is outside of bounds of a JavaScript Number.\n" +
-        "Use 'Datastore.int(<integer_value_as_string>)' to preserve accuracy during the upload.";
+        "Use 'Datastore.int(<integer_value_as_string>)' to preserve accuracy " +
+        'in your database.';
 
       process.on('warning', warning => {
         assert.strictEqual(warning.message, expectedWarning);
@@ -799,21 +800,21 @@ describe('entity', () => {
       assert.deepStrictEqual(entity.encodeValue(value), expectedValueProto);
     });
 
-    it('should encode a double', done => {
+    it.only('should encode a double', done => {
       const value = 8.3;
 
       const expectedValueProto = {
         doubleValue: value,
       };
 
-      const property = 'value';
+      const property = 'undefined';
       const expectedWarning =
         "TypeCastWarning: the value for '" +
         property +
         "' property is a JavaScript Number.\n" +
         "Use 'Datastore.int(<integer_value_as_string>)' or " +
         "'Datastore.double(<double_value_as_string>)' to preserve consistent " +
-        'Datastore types during the upload.';
+        'Datastore types in your database.';
 
       process.on('warning', warning => {
         assert.strictEqual(warning.message, expectedWarning);

--- a/test/entity.ts
+++ b/test/entity.ts
@@ -13,12 +13,12 @@
 // limitations under the License.
 
 import * as assert from 'assert';
-import {beforeEach, afterEach, describe, it} from 'mocha';
+import { beforeEach, afterEach, describe, it } from 'mocha';
 import * as extend from 'extend';
 import * as sinon from 'sinon';
-import {Datastore} from '../src';
-import {Entity} from '../src/entity';
-import {IntegerTypeCastOptions} from '../src/query';
+import { Datastore } from '../src';
+import { Entity } from '../src/entity';
+import { IntegerTypeCastOptions } from '../src/query';
 
 export function outOfBoundsError(opts: {
   propertyName?: string;
@@ -26,16 +26,16 @@ export function outOfBoundsError(opts: {
 }) {
   return new Error(
     'We attempted to return all of the numeric values, but ' +
-      (opts.propertyName ? opts.propertyName + ' ' : '') +
-      'value ' +
-      opts.integerValue +
-      " is out of bounds of 'Number.MAX_SAFE_INTEGER'.\n" +
-      "To prevent this error, please consider passing 'options.wrapNumbers=true' or\n" +
-      "'options.wrapNumbers' as\n" +
-      '{\n' +
-      '  integerTypeCastFunction: provide <your_custom_function>\n' +
-      '  properties: optionally specify property name(s) to be custom casted\n' +
-      '}\n'
+    (opts.propertyName ? opts.propertyName + ' ' : '') +
+    'value ' +
+    opts.integerValue +
+    " is out of bounds of 'Number.MAX_SAFE_INTEGER'.\n" +
+    "To prevent this error, please consider passing 'options.wrapNumbers=true' or\n" +
+    "'options.wrapNumbers' as\n" +
+    '{\n' +
+    '  integerTypeCastFunction: provide <your_custom_function>\n' +
+    '  properties: optionally specify property name(s) to be custom casted\n' +
+    '}\n'
   );
 }
 
@@ -156,12 +156,12 @@ describe('entity', () => {
           // should throw when Number is passed
           assert.throws(() => {
             new entity.Int(largeIntegerValue).valueOf();
-          }, outOfBoundsError({integerValue: largeIntegerValue}));
+          }, outOfBoundsError({ integerValue: largeIntegerValue }));
 
           // should throw when string is passed
           assert.throws(() => {
             new entity.Int(smallIntegerValue.toString()).valueOf();
-          }, outOfBoundsError({integerValue: smallIntegerValue}));
+          }, outOfBoundsError({ integerValue: smallIntegerValue }));
         });
 
         it('should not auto throw on initialization', () => {
@@ -272,12 +272,12 @@ describe('entity', () => {
 
   describe('isDsGeoPoint', () => {
     it('should correctly identify a GeoPoint', () => {
-      const geoPoint = new entity.GeoPoint({latitude: 24, longitude: 88});
+      const geoPoint = new entity.GeoPoint({ latitude: 24, longitude: 88 });
       assert.strictEqual(entity.isDsGeoPoint(geoPoint), true);
     });
 
     it('should correctly identify a homomorphic non-GeoPoint', () => {
-      const geoPoint = new entity.GeoPoint({latitude: 24, longitude: 88});
+      const geoPoint = new entity.GeoPoint({ latitude: 24, longitude: 88 });
       const nonGeoPoint = Object.assign({}, geoPoint);
       assert.strictEqual(entity.isDsGeoPoint(nonGeoPoint), false);
     });
@@ -286,47 +286,47 @@ describe('entity', () => {
   describe('Key', () => {
     it('should assign the namespace', () => {
       const namespace = 'NS';
-      const key = new entity.Key({namespace, path: []});
+      const key = new entity.Key({ namespace, path: [] });
       assert.strictEqual(key.namespace, namespace);
     });
 
     it('should assign the kind', () => {
       const kind = 'kind';
-      const key = new entity.Key({path: [kind]});
+      const key = new entity.Key({ path: [kind] });
       assert.strictEqual(key.kind, kind);
     });
 
     it('should assign the ID', () => {
       const id = 11;
-      const key = new entity.Key({path: ['Kind', id]});
+      const key = new entity.Key({ path: ['Kind', id] });
       assert.strictEqual(key.id, id);
     });
 
     it('should assign the ID from an Int', () => {
       const id = new entity.Int(11);
-      const key = new entity.Key({path: ['Kind', id]});
+      const key = new entity.Key({ path: ['Kind', id] });
       assert.strictEqual(key.id, id.value);
     });
 
     it('should assign the name', () => {
       const name = 'name';
-      const key = new entity.Key({path: ['Kind', name]});
+      const key = new entity.Key({ path: ['Kind', name] });
       assert.strictEqual(key.name, name);
     });
 
     it('should assign a parent', () => {
-      const key = new entity.Key({path: ['ParentKind', 1, 'Kind', 1]});
+      const key = new entity.Key({ path: ['ParentKind', 1, 'Kind', 1] });
       assert(key.parent instanceof entity.Key);
     });
 
     it('should not modify input path', () => {
       const inputPath = ['ParentKind', 1, 'Kind', 1];
-      new entity.Key({path: inputPath});
+      new entity.Key({ path: inputPath });
       assert.deepStrictEqual(inputPath, ['ParentKind', 1, 'Kind', 1]);
     });
 
     it('should always compute the correct path', () => {
-      const key = new entity.Key({path: ['ParentKind', 1, 'Kind', 1]});
+      const key = new entity.Key({ path: ['ParentKind', 1, 'Kind', 1] });
       assert.deepStrictEqual(key.path, ['ParentKind', 1, 'Kind', 1]);
 
       key.parent.kind = 'GrandParentKind';
@@ -373,12 +373,12 @@ describe('entity', () => {
 
   describe('isDsKey', () => {
     it('should correctly identify a Key', () => {
-      const key = new entity.Key({path: ['Kind', 1]});
+      const key = new entity.Key({ path: ['Kind', 1] });
       assert.strictEqual(entity.isDsKey(key), true);
     });
 
     it('should correctly identify a homomorphic non-Key', () => {
-      const notKey = Object.assign({}, new entity.Key({path: ['Kind', 1]}));
+      const notKey = Object.assign({}, new entity.Key({ path: ['Kind', 1] }));
       assert.strictEqual(entity.isDsKey(notKey), false);
     });
   });
@@ -594,7 +594,7 @@ describe('entity', () => {
         });
 
         it('should wrap ints with wrapNumbers as object', () => {
-          const wrapNumbers = {integerTypeCastFunction: () => {}};
+          const wrapNumbers = { integerTypeCastFunction: () => { } };
           const stub = sinon.spy(entity, 'Int');
 
           entity.decodeValueProto(valueProto, wrapNumbers);
@@ -602,11 +602,11 @@ describe('entity', () => {
         });
 
         it('should call #valueOf if integerTypeCastFunction is provided', () => {
-          Object.assign(valueProto, {integerValue: Number.MAX_SAFE_INTEGER});
+          Object.assign(valueProto, { integerValue: Number.MAX_SAFE_INTEGER });
           const takeFirstTen = sinon
             .stub()
             .callsFake((value: string) => value.toString().substr(0, 10));
-          const wrapNumbers = {integerTypeCastFunction: takeFirstTen};
+          const wrapNumbers = { integerTypeCastFunction: takeFirstTen };
 
           assert.strictEqual(
             entity.decodeValueProto(valueProto, wrapNumbers),
@@ -744,36 +744,17 @@ describe('entity', () => {
       assert.deepStrictEqual(entity.encodeValue(value), expectedValueProto);
     });
 
+    it('should throw if an invalid value was provided', () => {
+      assert.throws(() => {
+        entity.encodeValue();
+      }, /Unsupported field value/);
+    });
     it('should encode an int', () => {
       const value = 8;
 
-      const expectedValueProto = {
-        integerValue: value,
-      };
-
-      entity.Int = function (value_: {}) {
-        assert.strictEqual(value_, value);
-        this.value = value_;
-      };
-
-      assert.deepStrictEqual(entity.encodeValue(value), expectedValueProto);
-    });
-
-    it('should emit warning on out of bounce int', done => {
-      const largeIntValue = 9223372036854775807;
-      const property = 'largeInt';
-      const expectedWarning =
-        'IntegerOutOfBoundsWarning: ' +
-        "the value for '" +
-        property +
-        "' property is outside of bounds of a JavaScript Number.\n" +
-        "Use 'Datastore.int(<integer_value_as_string>)' to preserve accuracy during the upload.";
-
-      process.on('warning', warning => {
-        assert.strictEqual(warning.message, expectedWarning);
-        done();
-      });
-      entity.encodeValue(largeIntValue, property);
+      assert.throws(() => {
+        entity.encodeValue(value);
+      }, /The value for 'undefined' property is a JavaScript Number/);
     });
 
     it('should encode an Int object', () => {
@@ -789,16 +770,11 @@ describe('entity', () => {
     it('should encode a double', () => {
       const value = 8.3;
 
-      const expectedValueProto = {
-        doubleValue: value,
-      };
 
-      entity.Double = function (value_: {}) {
-        assert.strictEqual(value_, value);
-        this.value = value_;
-      };
+      assert.throws(() => {
+        entity.encodeValue(value);
+      }, /The value for 'undefined' property is a JavaScript Number/);
 
-      assert.deepStrictEqual(entity.encodeValue(value), expectedValueProto);
     });
 
     it('should encode a Double object', () => {
@@ -985,7 +961,7 @@ describe('entity', () => {
     });
 
     describe('should pass `wrapNumbers` to decodeValueProto', () => {
-      const entityProto = {properties: {number: {}}};
+      const entityProto = { properties: { number: {} } };
       let decodeValueProtoStub: sinon.SinonStub;
       let wrapNumbers: boolean | IntegerTypeCastOptions | undefined;
 
@@ -1017,7 +993,7 @@ describe('entity', () => {
 
       it('should pass `wrapNumbers` to decodeValueProto as IntegerTypeCastOptions', () => {
         const integerTypeCastOptions = {
-          integerTypeCastFunction: () => {},
+          integerTypeCastFunction: () => { },
           properties: 'that',
         };
 
@@ -1151,7 +1127,7 @@ describe('entity', () => {
 
           nestedArrayVariants: [
             {
-              a: [{b: value13}, {c: value14}],
+              a: [{ b: value13 }, { c: value14 }],
             },
             {
               a: null,
@@ -1160,7 +1136,7 @@ describe('entity', () => {
               a: [value15],
             },
             {
-              a: [{b: ['nasty', 'array']}],
+              a: [{ b: ['nasty', 'array'] }],
             },
           ],
 
@@ -1515,7 +1491,7 @@ describe('entity', () => {
     });
 
     describe('should pass `wrapNumbers` to entityFromEntityProto', () => {
-      const results = [{entity: {}}];
+      const results = [{ entity: {} }];
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       let entityFromEntityProtoStub: any;
       let wrapNumbers: boolean | IntegerTypeCastOptions | undefined;
@@ -1545,7 +1521,7 @@ describe('entity', () => {
 
       it('should pass `wrapNumbers` to entityFromEntityProto as IntegerTypeCastOptions', () => {
         const integerTypeCastOptions = {
-          integerTypeCastFunction: () => {},
+          integerTypeCastFunction: () => { },
           properties: 'that',
         };
 
@@ -1865,7 +1841,7 @@ describe('entity', () => {
         path: ['Kind2', 'somename'],
       });
 
-      const ds = new Datastore({projectId: 'project-id'});
+      const ds = new Datastore({ projectId: 'project-id' });
 
       const query = ds
         .createQuery('Kind1')
@@ -1883,7 +1859,7 @@ describe('entity', () => {
     });
 
     it('should handle buffer start and end values', () => {
-      const ds = new Datastore({projectId: 'project-id'});
+      const ds = new Datastore({ projectId: 'project-id' });
       const startVal = Buffer.from('start');
       const endVal = Buffer.from('end');
 

--- a/test/entity.ts
+++ b/test/entity.ts
@@ -744,17 +744,48 @@ describe('entity', () => {
       assert.deepStrictEqual(entity.encodeValue(value), expectedValueProto);
     });
 
-    it('should throw if an invalid value was provided', () => {
-      assert.throws(() => {
-        entity.encodeValue();
-      }, /Unsupported field value/);
-    });
-    it('should encode an int', () => {
+    it('should encode an int', done => {
       const value = 8;
 
-      assert.throws(() => {
-        entity.encodeValue(value);
-      }, /The value for 'undefined' property is a JavaScript Number/);
+      const expectedValueProto = {
+        integerValue: value,
+      };
+
+      const property = "value"
+      const expectedWarning = "TypeCastWarning: the value for '" +
+        property +
+        "' property is a JavaScript Number.\n" +
+        "Use 'Datastore.int(<integer_value_as_string>)' or " +
+        "'Datastore.double(<double_value_as_string>)' to preserve consistent " +
+        "Datastore types during the upload."
+      process.on('warning', warning => {
+        assert.strictEqual(warning.message, expectedWarning);
+        done();
+      });
+
+      entity.Int = function (value_: {}) {
+        assert.strictEqual(value_, value);
+        this.value = value_;
+      };
+
+      assert.deepStrictEqual(entity.encodeValue(value), expectedValueProto);
+    });
+
+    it('should emit warning on out of bounds int', done => {
+      const largeIntValue = 9223372036854775807;
+      const property = 'largeInt';
+      const expectedWarning =
+        'IntegerOutOfBoundsWarning: ' +
+        "the value for '" +
+        property +
+        "' property is outside of bounds of a JavaScript Number.\n" +
+        "Use 'Datastore.int(<integer_value_as_string>)' to preserve accuracy during the upload.";
+
+      process.on('warning', warning => {
+        assert.strictEqual(warning.message, expectedWarning);
+        done();
+      });
+      entity.encodeValue(largeIntValue, property);
     });
 
     it('should encode an Int object', () => {
@@ -767,14 +798,32 @@ describe('entity', () => {
       assert.deepStrictEqual(entity.encodeValue(value), expectedValueProto);
     });
 
-    it('should encode a double', () => {
+    it('should encode a double', done => {
       const value = 8.3;
 
+      const expectedValueProto = {
+        doubleValue: value,
+      };
 
-      assert.throws(() => {
-        entity.encodeValue(value);
-      }, /The value for 'undefined' property is a JavaScript Number/);
+      const property = "value"
+      const expectedWarning = "TypeCastWarning: the value for '" +
+        property +
+        "' property is a JavaScript Number.\n" +
+        "Use 'Datastore.int(<integer_value_as_string>)' or " +
+        "'Datastore.double(<double_value_as_string>)' to preserve consistent " +
+        "Datastore types during the upload."
 
+      process.on('warning', warning => {
+        assert.strictEqual(warning.message, expectedWarning);
+        done();
+      });
+
+      entity.Double = function (value_: {}) {
+        assert.strictEqual(value_, value);
+        this.value = value_;
+      };
+
+      assert.deepStrictEqual(entity.encodeValue(value), expectedValueProto);
     });
 
     it('should encode a Double object', () => {

--- a/test/entity.ts
+++ b/test/entity.ts
@@ -744,7 +744,7 @@ describe('entity', () => {
       assert.deepStrictEqual(entity.encodeValue(value), expectedValueProto);
     });
 
-    it.only('should encode an int', done => {
+    it('should encode an int', done => {
       const value = 8;
 
       const expectedValueProto = {
@@ -772,7 +772,7 @@ describe('entity', () => {
       assert.deepStrictEqual(entity.encodeValue(value), expectedValueProto);
     });
 
-    it.only('should emit warning on out of bounds int', done => {
+    it('should emit warning on out of bounds int', done => {
       const largeIntValue = 9223372036854775807;
       const property = 'largeInt';
       const expectedWarning =
@@ -800,7 +800,7 @@ describe('entity', () => {
       assert.deepStrictEqual(entity.encodeValue(value), expectedValueProto);
     });
 
-    it.only('should encode a double', done => {
+    it('should encode a double', done => {
       const value = 8.3;
 
       const expectedValueProto = {

--- a/test/entity.ts
+++ b/test/entity.ts
@@ -772,6 +772,37 @@ describe('entity', () => {
       assert.deepStrictEqual(entity.encodeValue(value), expectedValueProto);
     });
 
+    it('should encode an int but only warn once', done => {
+      const value = 8;
+
+      const expectedValueProto = {
+        integerValue: value,
+      };
+
+      const property = 'undefined';
+      const expectedWarning =
+        "TypeCastWarning: the value for '" +
+        property +
+        "' property is a JavaScript Number.\n" +
+        "Use 'Datastore.int(<integer_value_as_string>)' or " +
+        "'Datastore.double(<double_value_as_string>)' to preserve consistent " +
+        'Datastore types in your database.';
+      process.once('warning', warning => {
+        assert.strictEqual(warning.message, expectedWarning);
+        done();
+      });
+
+      entity.Int = function (value_: {}) {
+        assert.strictEqual(value_, value);
+        this.value = value_;
+      };
+
+      assert.deepStrictEqual(entity.encodeValue(value), expectedValueProto);
+      // if an error is reported on this, done() is called more than once and
+      // should cause failure.
+      assert.deepStrictEqual(entity.encodeValue(value), expectedValueProto);
+    });
+
     it('should emit warning on out of bounds int', done => {
       const largeIntValue = 9223372036854775807;
       const property = 'largeInt';

--- a/test/entity.ts
+++ b/test/entity.ts
@@ -759,7 +759,7 @@ describe('entity', () => {
         "Use 'Datastore.int(<integer_value_as_string>)' or " +
         "'Datastore.double(<double_value_as_string>)' to preserve consistent " +
         'Datastore types in your database.';
-      process.on('warning', warning => {
+      process.once('warning', warning => {
         assert.strictEqual(warning.message, expectedWarning);
         done();
       });
@@ -772,7 +772,7 @@ describe('entity', () => {
       assert.deepStrictEqual(entity.encodeValue(value), expectedValueProto);
     });
 
-    it('should emit warning on out of bounds int', done => {
+    it.only('should emit warning on out of bounds int', done => {
       const largeIntValue = 9223372036854775807;
       const property = 'largeInt';
       const expectedWarning =
@@ -783,7 +783,7 @@ describe('entity', () => {
         "Use 'Datastore.int(<integer_value_as_string>)' to preserve accuracy " +
         'in your database.';
 
-      process.on('warning', warning => {
+      process.once('warning', warning => {
         assert.strictEqual(warning.message, expectedWarning);
         done();
       });
@@ -816,7 +816,7 @@ describe('entity', () => {
         "'Datastore.double(<double_value_as_string>)' to preserve consistent " +
         'Datastore types in your database.';
 
-      process.on('warning', warning => {
+      process.once('warning', warning => {
         assert.strictEqual(warning.message, expectedWarning);
         done();
       });

--- a/test/index.ts
+++ b/test/index.ts
@@ -13,15 +13,15 @@
 // limitations under the License.
 
 import * as assert from 'assert';
-import { before, beforeEach, after, afterEach, describe, it } from 'mocha';
+import {before, beforeEach, after, afterEach, describe, it} from 'mocha';
 import * as gax from 'google-gax';
 import * as proxyquire from 'proxyquire';
-import { PassThrough, Readable } from 'stream';
+import {PassThrough, Readable} from 'stream';
 
 import * as ds from '../src';
-import { DatastoreOptions } from '../src';
-import { entity, Entity, EntityProto, EntityObject } from '../src/entity';
-import { RequestConfig } from '../src/request';
+import {DatastoreOptions} from '../src';
+import {entity, Entity, EntityProto, EntityObject} from '../src/entity';
+import {RequestConfig} from '../src/request';
 import * as is from 'is';
 import * as sinon from 'sinon';
 import * as extend from 'extend';
@@ -84,7 +84,7 @@ const fakeEntity: any = {
 
 let googleAuthOverride: Function | null;
 function fakeGoogleAuth(...args: Array<{}>) {
-  return (googleAuthOverride || (() => { }))(...args);
+  return (googleAuthOverride || (() => {}))(...args);
 }
 
 let createInsecureOverride: Function | null;
@@ -99,7 +99,7 @@ const fakeGoogleGax = {
         credentials: {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           createInsecure(...args: any[]) {
-            return (createInsecureOverride || (() => { }))(...args);
+            return (createInsecureOverride || (() => {}))(...args);
           },
         },
       } as {}) as gax.GrpcModule;
@@ -133,7 +133,7 @@ class FakeTransaction {
   }
 }
 
-function FakeV1() { }
+function FakeV1() {}
 
 const sandbox = sinon.createSandbox();
 
@@ -158,10 +158,10 @@ describe('Datastore', () => {
 
   before(() => {
     Datastore = proxyquire('../src', {
-      './entity.js': { entity: fakeEntity },
-      './index-class.js': { Index: FakeIndex },
-      './query.js': { Query: FakeQuery },
-      './transaction.js': { Transaction: FakeTransaction },
+      './entity.js': {entity: fakeEntity},
+      './index-class.js': {Index: FakeIndex},
+      './query.js': {Query: FakeQuery},
+      './transaction.js': {Transaction: FakeTransaction},
       './v1': FakeV1,
       'google-auth-library': {
         GoogleAuth: fakeGoogleAuth,
@@ -330,13 +330,13 @@ describe('Datastore', () => {
 
   describe('geoPoint', () => {
     it('should expose GeoPoint builder', () => {
-      const aGeoPoint = { latitude: 24, longitude: 88 };
+      const aGeoPoint = {latitude: 24, longitude: 88};
       const geoPoint = Datastore.geoPoint(aGeoPoint);
       assert.strictEqual(geoPoint.value, aGeoPoint);
     });
 
     it('should also be on the prototype', () => {
-      const aGeoPoint = { latitude: 24, longitude: 88 };
+      const aGeoPoint = {latitude: 24, longitude: 88};
       const geoPoint = datastore.geoPoint(aGeoPoint);
       assert.strictEqual(geoPoint.value, aGeoPoint);
     });
@@ -380,7 +380,7 @@ describe('Datastore', () => {
 
   describe('isGeoPoint', () => {
     it('should pass value to entity', () => {
-      const value = { fakeLatitude: 1, fakeLongitude: 2 };
+      const value = {fakeLatitude: 1, fakeLongitude: 2};
       let called = false;
       const saved = fakeEntity.isDsGeoPoint;
       fakeEntity.isDsGeoPoint = (arg: {}) => {
@@ -424,7 +424,7 @@ describe('Datastore', () => {
 
   describe('isKey', () => {
     it('should pass value to entity', () => {
-      const value = { zz: true };
+      const value = {zz: true};
       let called = false;
       const saved = fakeEntity.isDsKey;
       fakeEntity.isDsKey = (arg: {}) => {
@@ -538,7 +538,7 @@ describe('Datastore', () => {
         done();
       };
 
-      datastore.export({ bucket }, assert.ifError);
+      datastore.export({bucket}, assert.ifError);
     });
 
     it('should remove extraneous gs:// prefix from input', done => {
@@ -550,11 +550,11 @@ describe('Datastore', () => {
         done();
       };
 
-      datastore.export({ bucket }, assert.ifError);
+      datastore.export({bucket}, assert.ifError);
     });
 
     it('should accept a Bucket object destination', done => {
-      const bucket = { name: 'bucket' };
+      const bucket = {name: 'bucket'};
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       datastore.request_ = (config: any) => {
@@ -565,7 +565,7 @@ describe('Datastore', () => {
         done();
       };
 
-      datastore.export({ bucket }, assert.ifError);
+      datastore.export({bucket}, assert.ifError);
     });
 
     it('should throw if a destination is not provided', () => {
@@ -588,7 +588,7 @@ describe('Datastore', () => {
 
     it('should accept kinds', done => {
       const kinds = ['kind1', 'kind2'];
-      const config = { bucket: 'bucket', kinds };
+      const config = {bucket: 'bucket', kinds};
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       datastore.request_ = (config: any) => {
@@ -614,7 +614,7 @@ describe('Datastore', () => {
 
     it('should accept namespaces', done => {
       const namespaces = ['ns1', 'n2'];
-      const config = { bucket: 'bucket', namespaces };
+      const config = {bucket: 'bucket', namespaces};
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       datastore.request_ = (config: any) => {
@@ -663,7 +663,7 @@ describe('Datastore', () => {
 
     it('should send any user input to API', done => {
       const userProperty = 'abc';
-      const config = { bucket: 'bucket', userProperty };
+      const config = {bucket: 'bucket', userProperty};
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       datastore.request_ = (config: any) => {
@@ -675,7 +675,7 @@ describe('Datastore', () => {
     });
 
     it('should send correct request', done => {
-      const config = { bucket: 'bucket' };
+      const config = {bucket: 'bucket'};
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       datastore.request_ = (config: any) => {
@@ -690,7 +690,7 @@ describe('Datastore', () => {
 
     it('should accept gaxOptions', done => {
       const gaxOptions = {};
-      const config = { bucket: 'bucket', gaxOptions };
+      const config = {bucket: 'bucket', gaxOptions};
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       datastore.request_ = (config: any) => {
@@ -704,7 +704,7 @@ describe('Datastore', () => {
 
   describe('getIndexes', () => {
     it('should send the correct request', done => {
-      const options = { a: 'b' };
+      const options = {a: 'b'};
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       datastore.request_ = (config: any) => {
@@ -789,7 +789,7 @@ describe('Datastore', () => {
 
     it('should accept gaxOptions', done => {
       const options = {
-        gaxOptions: { a: 'b' },
+        gaxOptions: {a: 'b'},
       };
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -804,7 +804,7 @@ describe('Datastore', () => {
 
     it('should not send gaxOptions as request options', done => {
       const options = {
-        gaxOptions: { a: 'b' },
+        gaxOptions: {a: 'b'},
       };
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -868,7 +868,7 @@ describe('Datastore', () => {
     });
 
     it('should execute callback with Index instances', done => {
-      const rawIndex = { indexId: 'name', a: 'b' };
+      const rawIndex = {indexId: 'name', a: 'b'};
       const indexInstance = {};
 
       datastore.index = (id: string) => {
@@ -892,8 +892,8 @@ describe('Datastore', () => {
     });
 
     it('should execute callback with prepared nextQuery', done => {
-      const options = { pageToken: '1' };
-      const nextQuery = { pageToken: '2' };
+      const options = {pageToken: '1'};
+      const nextQuery = {pageToken: '2'};
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       datastore.request_ = (config: any, callback: Function) => {
@@ -913,7 +913,7 @@ describe('Datastore', () => {
 
   describe('getIndexesStream', () => {
     it('should make correct request', done => {
-      const options = { a: 'b' };
+      const options = {a: 'b'};
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       datastore.requestStream_ = (config: any) => {
@@ -931,7 +931,7 @@ describe('Datastore', () => {
     });
 
     it('should accept gaxOptions', done => {
-      const options = { gaxOptions: {} };
+      const options = {gaxOptions: {}};
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       datastore.requestStream_ = (config: any) => {
@@ -944,7 +944,7 @@ describe('Datastore', () => {
     });
 
     it('should transform response indexes into Index objects', done => {
-      const rawIndex = { indexId: 'name', a: 'b' };
+      const rawIndex = {indexId: 'name', a: 'b'};
       const indexInstance = {};
       const requestStream = new Readable({
         objectMode: true,
@@ -996,7 +996,7 @@ describe('Datastore', () => {
         done();
       };
 
-      datastore.import({ file }, assert.ifError);
+      datastore.import({file}, assert.ifError);
     });
 
     it('should remove extraneous gs:// prefix from input', done => {
@@ -1008,11 +1008,11 @@ describe('Datastore', () => {
         done();
       };
 
-      datastore.import({ file }, assert.ifError);
+      datastore.import({file}, assert.ifError);
     });
 
     it('should accept a File object source', done => {
-      const file = { bucket: { name: 'bucket' }, name: 'file' };
+      const file = {bucket: {name: 'bucket'}, name: 'file'};
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       datastore.request_ = (config: any) => {
@@ -1023,7 +1023,7 @@ describe('Datastore', () => {
         done();
       };
 
-      datastore.import({ file }, assert.ifError);
+      datastore.import({file}, assert.ifError);
     });
 
     it('should throw if a source is not provided', () => {
@@ -1034,7 +1034,7 @@ describe('Datastore', () => {
 
     it('should accept kinds', done => {
       const kinds = ['kind1', 'kind2'];
-      const config = { file: 'file', kinds };
+      const config = {file: 'file', kinds};
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       datastore.request_ = (config: any) => {
@@ -1060,7 +1060,7 @@ describe('Datastore', () => {
 
     it('should accept namespaces', done => {
       const namespaces = ['ns1', 'n2'];
-      const config = { file: 'file', namespaces };
+      const config = {file: 'file', namespaces};
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       datastore.request_ = (config: any) => {
@@ -1109,7 +1109,7 @@ describe('Datastore', () => {
 
     it('should send any user input to API', done => {
       const userProperty = 'abc';
-      const config = { file: 'file', userProperty };
+      const config = {file: 'file', userProperty};
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       datastore.request_ = (config: any) => {
@@ -1121,7 +1121,7 @@ describe('Datastore', () => {
     });
 
     it('should send correct request', done => {
-      const config = { file: 'file' };
+      const config = {file: 'file'};
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       datastore.request_ = (config: any) => {
@@ -1136,7 +1136,7 @@ describe('Datastore', () => {
 
     it('should accept gaxOptions', done => {
       const gaxOptions = {};
-      const config = { file: 'file', gaxOptions };
+      const config = {file: 'file', gaxOptions};
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       datastore.request_ = (config: any) => {
@@ -1167,7 +1167,7 @@ describe('Datastore', () => {
 
     it('should prepare entity objects', done => {
       const entityObject = {};
-      const preparedEntityObject = { prepared: true };
+      const preparedEntityObject = {prepared: true};
       const expectedEntityObject = Object.assign({}, preparedEntityObject, {
         method: 'insert',
       });
@@ -1202,8 +1202,8 @@ describe('Datastore', () => {
         ]);
         callback();
       };
-      const key = new entity.Key({ namespace: 'ns', path: ['Company'] });
-      datastore.insert({ key, data: {} }, done);
+      const key = new entity.Key({namespace: 'ns', path: ['Company']});
+      datastore.insert({key, data: {}}, done);
     });
   });
 
@@ -1297,8 +1297,8 @@ describe('Datastore', () => {
       };
       datastore.save(
         [
-          { key, data: { k: 'v' } },
-          { key, data: { k: 'v' } },
+          {key, data: {k: 'v'}},
+          {key, data: {k: 'v'}},
         ],
         done
       );
@@ -1380,7 +1380,7 @@ describe('Datastore', () => {
           return {
             key,
             method: 'insert',
-            data: { k: 'v' },
+            data: {k: 'v'},
           } as {};
         });
 
@@ -1400,22 +1400,22 @@ describe('Datastore', () => {
         assert(is.object(config.reqOpts!.mutations![2].upsert));
 
         const insert = config.reqOpts!.mutations![0].insert!;
-        assert.deepStrictEqual(insert.properties!.k, { stringValue: 'v' });
+        assert.deepStrictEqual(insert.properties!.k, {stringValue: 'v'});
 
         const update = config.reqOpts!.mutations![1].update!;
-        assert.deepStrictEqual(update.properties!.k2, { stringValue: 'v2' });
+        assert.deepStrictEqual(update.properties!.k2, {stringValue: 'v2'});
 
         const upsert = config.reqOpts!.mutations![2].upsert!;
-        assert.deepStrictEqual(upsert.properties!.k3, { stringValue: 'v3' });
+        assert.deepStrictEqual(upsert.properties!.k3, {stringValue: 'v3'});
 
         callback();
       };
 
       datastore.save(
         [
-          { key, method: 'insert', data: { k: 'v' } },
-          { key, method: 'update', data: { k2: 'v2' } },
-          { key, method: 'upsert', data: { k3: 'v3' } },
+          {key, method: 'insert', data: {k: 'v'}},
+          {key, method: 'update', data: {k2: 'v2'}},
+          {key, method: 'upsert', data: {k3: 'v3'}},
         ],
         done
       );
@@ -1463,13 +1463,13 @@ describe('Datastore', () => {
     });
 
     it('should return apiResponse in callback', done => {
-      const key = new entity.Key({ namespace: 'ns', path: ['Company'] });
+      const key = new entity.Key({namespace: 'ns', path: ['Company']});
       const mockCommitResponse = {};
       datastore.request_ = (config: RequestConfig, callback: Function) => {
         callback(null, mockCommitResponse);
       };
       datastore.save(
-        { key, data: {} },
+        {key, data: {}},
         (err: Error | null, apiResponse: Entity) => {
           assert.ifError(err);
           assert.strictEqual(mockCommitResponse, apiResponse);
@@ -1820,9 +1820,9 @@ describe('Datastore', () => {
     });
 
     it('should assign ID on keys without them', done => {
-      const incompleteKey = new entity.Key({ path: ['Incomplete'] });
-      const incompleteKey2 = new entity.Key({ path: ['Incomplete'] });
-      const completeKey = new entity.Key({ path: ['Complete', 'Key'] });
+      const incompleteKey = new entity.Key({path: ['Incomplete']});
+      const incompleteKey2 = new entity.Key({path: ['Incomplete']});
+      const completeKey = new entity.Key({path: ['Complete', 'Key']});
 
       const keyProtos: Array<{}> = [];
       const ids = [1, 2];
@@ -1852,9 +1852,9 @@ describe('Datastore', () => {
 
       datastore.save(
         [
-          { key: incompleteKey, data: {} },
-          { key: incompleteKey2, data: {} },
-          { key: completeKey, data: {} },
+          {key: incompleteKey, data: {}},
+          {key: incompleteKey2, data: {}},
+          {key: completeKey, data: {}},
         ],
         (err: Error) => {
           assert.ifError(err);
@@ -1882,7 +1882,7 @@ describe('Datastore', () => {
       it('should queue request & callback', () => {
         datastore.save({
           key,
-          data: [{ name: 'name', value: 'value' }],
+          data: [{name: 'name', value: 'value'}],
         });
 
         assert.strictEqual(typeof datastore.requestCallbacks_[0], 'function');
@@ -1898,7 +1898,7 @@ describe('Datastore', () => {
 
     it('should prepare entity objects', done => {
       const entityObject = {};
-      const preparedEntityObject = { prepared: true };
+      const preparedEntityObject = {prepared: true};
       const expectedEntityObject = Object.assign({}, preparedEntityObject, {
         method: 'update',
       });
@@ -1934,8 +1934,8 @@ describe('Datastore', () => {
         callback();
       };
 
-      const key = new entity.Key({ namespace: 'ns', path: ['Company'] });
-      datastore.update({ key, data: {} }, done);
+      const key = new entity.Key({namespace: 'ns', path: ['Company']});
+      datastore.update({key, data: {}}, done);
     });
   });
 
@@ -1946,7 +1946,7 @@ describe('Datastore', () => {
 
     it('should prepare entity objects', done => {
       const entityObject = {};
-      const preparedEntityObject = { prepared: true };
+      const preparedEntityObject = {prepared: true};
       const expectedEntityObject = Object.assign({}, preparedEntityObject, {
         method: 'upsert',
       });
@@ -1983,8 +1983,8 @@ describe('Datastore', () => {
         callback();
       };
 
-      const key = new entity.Key({ namespace: 'ns', path: ['Company'] });
-      datastore.upsert({ key, data: {} }, done);
+      const key = new entity.Key({namespace: 'ns', path: ['Company']});
+      datastore.upsert({key, data: {}}, done);
     });
   });
 
@@ -2047,7 +2047,7 @@ describe('Datastore', () => {
     });
 
     it('should not set customEndpoint_ when using default baseurl', () => {
-      const datastore = new Datastore({ projectId: PROJECT_ID });
+      const datastore = new Datastore({projectId: PROJECT_ID});
       datastore.determineBaseUrl_();
       assert.strictEqual(datastore.customEndpoint_, undefined);
     });

--- a/test/index.ts
+++ b/test/index.ts
@@ -13,15 +13,15 @@
 // limitations under the License.
 
 import * as assert from 'assert';
-import {before, beforeEach, after, afterEach, describe, it} from 'mocha';
+import { before, beforeEach, after, afterEach, describe, it } from 'mocha';
 import * as gax from 'google-gax';
 import * as proxyquire from 'proxyquire';
-import {PassThrough, Readable} from 'stream';
+import { PassThrough, Readable } from 'stream';
 
 import * as ds from '../src';
-import {DatastoreOptions} from '../src';
-import {entity, Entity, EntityProto, EntityObject} from '../src/entity';
-import {RequestConfig} from '../src/request';
+import { DatastoreOptions } from '../src';
+import { entity, Entity, EntityProto, EntityObject } from '../src/entity';
+import { RequestConfig } from '../src/request';
 import * as is from 'is';
 import * as sinon from 'sinon';
 import * as extend from 'extend';
@@ -34,8 +34,10 @@ const fakeEntity: any = {
   KEY_SYMBOL: Symbol('fake key symbol'),
   Int: class {
     value: {};
+    type: string;
     constructor(value: {}) {
       this.value = value;
+      this.type = 'DatastoreInt';
     }
   },
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -44,8 +46,11 @@ const fakeEntity: any = {
   },
   Double: class {
     value: {};
+    type: string;
+
     constructor(value: {}) {
       this.value = value;
+      this.type = 'DatastoreDouble';
     }
   },
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -84,7 +89,7 @@ const fakeEntity: any = {
 
 let googleAuthOverride: Function | null;
 function fakeGoogleAuth(...args: Array<{}>) {
-  return (googleAuthOverride || (() => {}))(...args);
+  return (googleAuthOverride || (() => { }))(...args);
 }
 
 let createInsecureOverride: Function | null;
@@ -99,7 +104,7 @@ const fakeGoogleGax = {
         credentials: {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           createInsecure(...args: any[]) {
-            return (createInsecureOverride || (() => {}))(...args);
+            return (createInsecureOverride || (() => { }))(...args);
           },
         },
       } as {}) as gax.GrpcModule;
@@ -133,7 +138,7 @@ class FakeTransaction {
   }
 }
 
-function FakeV1() {}
+function FakeV1() { }
 
 const sandbox = sinon.createSandbox();
 
@@ -158,10 +163,10 @@ describe('Datastore', () => {
 
   before(() => {
     Datastore = proxyquire('../src', {
-      './entity.js': {entity: fakeEntity},
-      './index-class.js': {Index: FakeIndex},
-      './query.js': {Query: FakeQuery},
-      './transaction.js': {Transaction: FakeTransaction},
+      './entity.js': { entity: fakeEntity },
+      './index-class.js': { Index: FakeIndex },
+      './query.js': { Query: FakeQuery },
+      './transaction.js': { Transaction: FakeTransaction },
       './v1': FakeV1,
       'google-auth-library': {
         GoogleAuth: fakeGoogleAuth,
@@ -330,13 +335,13 @@ describe('Datastore', () => {
 
   describe('geoPoint', () => {
     it('should expose GeoPoint builder', () => {
-      const aGeoPoint = {latitude: 24, longitude: 88};
+      const aGeoPoint = { latitude: 24, longitude: 88 };
       const geoPoint = Datastore.geoPoint(aGeoPoint);
       assert.strictEqual(geoPoint.value, aGeoPoint);
     });
 
     it('should also be on the prototype', () => {
-      const aGeoPoint = {latitude: 24, longitude: 88};
+      const aGeoPoint = { latitude: 24, longitude: 88 };
       const geoPoint = datastore.geoPoint(aGeoPoint);
       assert.strictEqual(geoPoint.value, aGeoPoint);
     });
@@ -380,7 +385,7 @@ describe('Datastore', () => {
 
   describe('isGeoPoint', () => {
     it('should pass value to entity', () => {
-      const value = {fakeLatitude: 1, fakeLongitude: 2};
+      const value = { fakeLatitude: 1, fakeLongitude: 2 };
       let called = false;
       const saved = fakeEntity.isDsGeoPoint;
       fakeEntity.isDsGeoPoint = (arg: {}) => {
@@ -424,7 +429,7 @@ describe('Datastore', () => {
 
   describe('isKey', () => {
     it('should pass value to entity', () => {
-      const value = {zz: true};
+      const value = { zz: true };
       let called = false;
       const saved = fakeEntity.isDsKey;
       fakeEntity.isDsKey = (arg: {}) => {
@@ -538,7 +543,7 @@ describe('Datastore', () => {
         done();
       };
 
-      datastore.export({bucket}, assert.ifError);
+      datastore.export({ bucket }, assert.ifError);
     });
 
     it('should remove extraneous gs:// prefix from input', done => {
@@ -550,11 +555,11 @@ describe('Datastore', () => {
         done();
       };
 
-      datastore.export({bucket}, assert.ifError);
+      datastore.export({ bucket }, assert.ifError);
     });
 
     it('should accept a Bucket object destination', done => {
-      const bucket = {name: 'bucket'};
+      const bucket = { name: 'bucket' };
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       datastore.request_ = (config: any) => {
@@ -565,7 +570,7 @@ describe('Datastore', () => {
         done();
       };
 
-      datastore.export({bucket}, assert.ifError);
+      datastore.export({ bucket }, assert.ifError);
     });
 
     it('should throw if a destination is not provided', () => {
@@ -588,7 +593,7 @@ describe('Datastore', () => {
 
     it('should accept kinds', done => {
       const kinds = ['kind1', 'kind2'];
-      const config = {bucket: 'bucket', kinds};
+      const config = { bucket: 'bucket', kinds };
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       datastore.request_ = (config: any) => {
@@ -614,7 +619,7 @@ describe('Datastore', () => {
 
     it('should accept namespaces', done => {
       const namespaces = ['ns1', 'n2'];
-      const config = {bucket: 'bucket', namespaces};
+      const config = { bucket: 'bucket', namespaces };
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       datastore.request_ = (config: any) => {
@@ -663,7 +668,7 @@ describe('Datastore', () => {
 
     it('should send any user input to API', done => {
       const userProperty = 'abc';
-      const config = {bucket: 'bucket', userProperty};
+      const config = { bucket: 'bucket', userProperty };
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       datastore.request_ = (config: any) => {
@@ -675,7 +680,7 @@ describe('Datastore', () => {
     });
 
     it('should send correct request', done => {
-      const config = {bucket: 'bucket'};
+      const config = { bucket: 'bucket' };
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       datastore.request_ = (config: any) => {
@@ -690,7 +695,7 @@ describe('Datastore', () => {
 
     it('should accept gaxOptions', done => {
       const gaxOptions = {};
-      const config = {bucket: 'bucket', gaxOptions};
+      const config = { bucket: 'bucket', gaxOptions };
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       datastore.request_ = (config: any) => {
@@ -704,7 +709,7 @@ describe('Datastore', () => {
 
   describe('getIndexes', () => {
     it('should send the correct request', done => {
-      const options = {a: 'b'};
+      const options = { a: 'b' };
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       datastore.request_ = (config: any) => {
@@ -789,7 +794,7 @@ describe('Datastore', () => {
 
     it('should accept gaxOptions', done => {
       const options = {
-        gaxOptions: {a: 'b'},
+        gaxOptions: { a: 'b' },
       };
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -804,7 +809,7 @@ describe('Datastore', () => {
 
     it('should not send gaxOptions as request options', done => {
       const options = {
-        gaxOptions: {a: 'b'},
+        gaxOptions: { a: 'b' },
       };
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -868,7 +873,7 @@ describe('Datastore', () => {
     });
 
     it('should execute callback with Index instances', done => {
-      const rawIndex = {indexId: 'name', a: 'b'};
+      const rawIndex = { indexId: 'name', a: 'b' };
       const indexInstance = {};
 
       datastore.index = (id: string) => {
@@ -892,8 +897,8 @@ describe('Datastore', () => {
     });
 
     it('should execute callback with prepared nextQuery', done => {
-      const options = {pageToken: '1'};
-      const nextQuery = {pageToken: '2'};
+      const options = { pageToken: '1' };
+      const nextQuery = { pageToken: '2' };
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       datastore.request_ = (config: any, callback: Function) => {
@@ -913,7 +918,7 @@ describe('Datastore', () => {
 
   describe('getIndexesStream', () => {
     it('should make correct request', done => {
-      const options = {a: 'b'};
+      const options = { a: 'b' };
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       datastore.requestStream_ = (config: any) => {
@@ -931,7 +936,7 @@ describe('Datastore', () => {
     });
 
     it('should accept gaxOptions', done => {
-      const options = {gaxOptions: {}};
+      const options = { gaxOptions: {} };
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       datastore.requestStream_ = (config: any) => {
@@ -944,7 +949,7 @@ describe('Datastore', () => {
     });
 
     it('should transform response indexes into Index objects', done => {
-      const rawIndex = {indexId: 'name', a: 'b'};
+      const rawIndex = { indexId: 'name', a: 'b' };
       const indexInstance = {};
       const requestStream = new Readable({
         objectMode: true,
@@ -996,7 +1001,7 @@ describe('Datastore', () => {
         done();
       };
 
-      datastore.import({file}, assert.ifError);
+      datastore.import({ file }, assert.ifError);
     });
 
     it('should remove extraneous gs:// prefix from input', done => {
@@ -1008,11 +1013,11 @@ describe('Datastore', () => {
         done();
       };
 
-      datastore.import({file}, assert.ifError);
+      datastore.import({ file }, assert.ifError);
     });
 
     it('should accept a File object source', done => {
-      const file = {bucket: {name: 'bucket'}, name: 'file'};
+      const file = { bucket: { name: 'bucket' }, name: 'file' };
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       datastore.request_ = (config: any) => {
@@ -1023,7 +1028,7 @@ describe('Datastore', () => {
         done();
       };
 
-      datastore.import({file}, assert.ifError);
+      datastore.import({ file }, assert.ifError);
     });
 
     it('should throw if a source is not provided', () => {
@@ -1034,7 +1039,7 @@ describe('Datastore', () => {
 
     it('should accept kinds', done => {
       const kinds = ['kind1', 'kind2'];
-      const config = {file: 'file', kinds};
+      const config = { file: 'file', kinds };
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       datastore.request_ = (config: any) => {
@@ -1060,7 +1065,7 @@ describe('Datastore', () => {
 
     it('should accept namespaces', done => {
       const namespaces = ['ns1', 'n2'];
-      const config = {file: 'file', namespaces};
+      const config = { file: 'file', namespaces };
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       datastore.request_ = (config: any) => {
@@ -1109,7 +1114,7 @@ describe('Datastore', () => {
 
     it('should send any user input to API', done => {
       const userProperty = 'abc';
-      const config = {file: 'file', userProperty};
+      const config = { file: 'file', userProperty };
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       datastore.request_ = (config: any) => {
@@ -1121,7 +1126,7 @@ describe('Datastore', () => {
     });
 
     it('should send correct request', done => {
-      const config = {file: 'file'};
+      const config = { file: 'file' };
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       datastore.request_ = (config: any) => {
@@ -1136,7 +1141,7 @@ describe('Datastore', () => {
 
     it('should accept gaxOptions', done => {
       const gaxOptions = {};
-      const config = {file: 'file', gaxOptions};
+      const config = { file: 'file', gaxOptions };
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       datastore.request_ = (config: any) => {
@@ -1167,7 +1172,7 @@ describe('Datastore', () => {
 
     it('should prepare entity objects', done => {
       const entityObject = {};
-      const preparedEntityObject = {prepared: true};
+      const preparedEntityObject = { prepared: true };
       const expectedEntityObject = Object.assign({}, preparedEntityObject, {
         method: 'insert',
       });
@@ -1202,8 +1207,8 @@ describe('Datastore', () => {
         ]);
         callback();
       };
-      const key = new entity.Key({namespace: 'ns', path: ['Company']});
-      datastore.insert({key, data: {}}, done);
+      const key = new entity.Key({ namespace: 'ns', path: ['Company'] });
+      datastore.insert({ key, data: {} }, done);
     });
   });
 
@@ -1297,8 +1302,8 @@ describe('Datastore', () => {
       };
       datastore.save(
         [
-          {key, data: {k: 'v'}},
-          {key, data: {k: 'v'}},
+          { key, data: { k: 'v' } },
+          { key, data: { k: 'v' } },
         ],
         done
       );
@@ -1316,7 +1321,7 @@ describe('Datastore', () => {
           arrayValue: {
             values: [
               {
-                integerValue: '0',
+                integerValue: 0,
               },
               {
                 nullValue: 0,
@@ -1342,7 +1347,7 @@ describe('Datastore', () => {
         data: {
           stringField: 'string value',
           nullField: null,
-          arrayField: [0, null],
+          arrayField: [Datastore.int(0), null],
           objectField: null,
         },
         excludeLargeProperties: true,
@@ -1380,7 +1385,7 @@ describe('Datastore', () => {
           return {
             key,
             method: 'insert',
-            data: {k: 'v'},
+            data: { k: 'v' },
           } as {};
         });
 
@@ -1400,22 +1405,22 @@ describe('Datastore', () => {
         assert(is.object(config.reqOpts!.mutations![2].upsert));
 
         const insert = config.reqOpts!.mutations![0].insert!;
-        assert.deepStrictEqual(insert.properties!.k, {stringValue: 'v'});
+        assert.deepStrictEqual(insert.properties!.k, { stringValue: 'v' });
 
         const update = config.reqOpts!.mutations![1].update!;
-        assert.deepStrictEqual(update.properties!.k2, {stringValue: 'v2'});
+        assert.deepStrictEqual(update.properties!.k2, { stringValue: 'v2' });
 
         const upsert = config.reqOpts!.mutations![2].upsert!;
-        assert.deepStrictEqual(upsert.properties!.k3, {stringValue: 'v3'});
+        assert.deepStrictEqual(upsert.properties!.k3, { stringValue: 'v3' });
 
         callback();
       };
 
       datastore.save(
         [
-          {key, method: 'insert', data: {k: 'v'}},
-          {key, method: 'update', data: {k2: 'v2'}},
-          {key, method: 'upsert', data: {k3: 'v3'}},
+          { key, method: 'insert', data: { k: 'v' } },
+          { key, method: 'update', data: { k2: 'v2' } },
+          { key, method: 'upsert', data: { k3: 'v3' } },
         ],
         done
       );
@@ -1445,7 +1450,7 @@ describe('Datastore', () => {
           data: {
             value: {
               a: 'b',
-              c: [1, 2, 3],
+              c: [ds.Datastore.int(1), ds.Datastore.int(2), ds.Datastore.int(3)],
             },
           },
         },
@@ -1463,13 +1468,13 @@ describe('Datastore', () => {
     });
 
     it('should return apiResponse in callback', done => {
-      const key = new entity.Key({namespace: 'ns', path: ['Company']});
+      const key = new entity.Key({ namespace: 'ns', path: ['Company'] });
       const mockCommitResponse = {};
       datastore.request_ = (config: RequestConfig, callback: Function) => {
         callback(null, mockCommitResponse);
       };
       datastore.save(
-        {key, data: {}},
+        { key, data: {} },
         (err: Error | null, apiResponse: Entity) => {
           assert.ifError(err);
           assert.strictEqual(mockCommitResponse, apiResponse);
@@ -1820,9 +1825,9 @@ describe('Datastore', () => {
     });
 
     it('should assign ID on keys without them', done => {
-      const incompleteKey = new entity.Key({path: ['Incomplete']});
-      const incompleteKey2 = new entity.Key({path: ['Incomplete']});
-      const completeKey = new entity.Key({path: ['Complete', 'Key']});
+      const incompleteKey = new entity.Key({ path: ['Incomplete'] });
+      const incompleteKey2 = new entity.Key({ path: ['Incomplete'] });
+      const completeKey = new entity.Key({ path: ['Complete', 'Key'] });
 
       const keyProtos: Array<{}> = [];
       const ids = [1, 2];
@@ -1852,9 +1857,9 @@ describe('Datastore', () => {
 
       datastore.save(
         [
-          {key: incompleteKey, data: {}},
-          {key: incompleteKey2, data: {}},
-          {key: completeKey, data: {}},
+          { key: incompleteKey, data: {} },
+          { key: incompleteKey2, data: {} },
+          { key: completeKey, data: {} },
         ],
         (err: Error) => {
           assert.ifError(err);
@@ -1882,7 +1887,7 @@ describe('Datastore', () => {
       it('should queue request & callback', () => {
         datastore.save({
           key,
-          data: [{name: 'name', value: 'value'}],
+          data: [{ name: 'name', value: 'value' }],
         });
 
         assert.strictEqual(typeof datastore.requestCallbacks_[0], 'function');
@@ -1898,7 +1903,7 @@ describe('Datastore', () => {
 
     it('should prepare entity objects', done => {
       const entityObject = {};
-      const preparedEntityObject = {prepared: true};
+      const preparedEntityObject = { prepared: true };
       const expectedEntityObject = Object.assign({}, preparedEntityObject, {
         method: 'update',
       });
@@ -1934,8 +1939,8 @@ describe('Datastore', () => {
         callback();
       };
 
-      const key = new entity.Key({namespace: 'ns', path: ['Company']});
-      datastore.update({key, data: {}}, done);
+      const key = new entity.Key({ namespace: 'ns', path: ['Company'] });
+      datastore.update({ key, data: {} }, done);
     });
   });
 
@@ -1946,7 +1951,7 @@ describe('Datastore', () => {
 
     it('should prepare entity objects', done => {
       const entityObject = {};
-      const preparedEntityObject = {prepared: true};
+      const preparedEntityObject = { prepared: true };
       const expectedEntityObject = Object.assign({}, preparedEntityObject, {
         method: 'upsert',
       });
@@ -1983,8 +1988,8 @@ describe('Datastore', () => {
         callback();
       };
 
-      const key = new entity.Key({namespace: 'ns', path: ['Company']});
-      datastore.upsert({key, data: {}}, done);
+      const key = new entity.Key({ namespace: 'ns', path: ['Company'] });
+      datastore.upsert({ key, data: {} }, done);
     });
   });
 
@@ -2047,7 +2052,7 @@ describe('Datastore', () => {
     });
 
     it('should not set customEndpoint_ when using default baseurl', () => {
-      const datastore = new Datastore({projectId: PROJECT_ID});
+      const datastore = new Datastore({ projectId: PROJECT_ID });
       datastore.determineBaseUrl_();
       assert.strictEqual(datastore.customEndpoint_, undefined);
     });

--- a/test/index.ts
+++ b/test/index.ts
@@ -1316,7 +1316,13 @@ describe('Datastore', () => {
           arrayValue: {
             values: [
               {
-                integerValue: '0',
+                entityValue: {
+                  properties: {
+                    value: {
+                      integerValue: '0',
+                    },
+                  },
+                },
               },
               {
                 nullValue: 0,

--- a/test/index.ts
+++ b/test/index.ts
@@ -34,10 +34,8 @@ const fakeEntity: any = {
   KEY_SYMBOL: Symbol('fake key symbol'),
   Int: class {
     value: {};
-    type: string;
     constructor(value: {}) {
       this.value = value;
-      this.type = 'DatastoreInt';
     }
   },
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -46,11 +44,8 @@ const fakeEntity: any = {
   },
   Double: class {
     value: {};
-    type: string;
-
     constructor(value: {}) {
       this.value = value;
-      this.type = 'DatastoreDouble';
     }
   },
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1321,7 +1316,7 @@ describe('Datastore', () => {
           arrayValue: {
             values: [
               {
-                integerValue: 0,
+                integerValue: '0',
               },
               {
                 nullValue: 0,
@@ -1347,7 +1342,7 @@ describe('Datastore', () => {
         data: {
           stringField: 'string value',
           nullField: null,
-          arrayField: [Datastore.int(0), null],
+          arrayField: [datastore.int(0), null],
           objectField: null,
         },
         excludeLargeProperties: true,
@@ -1450,7 +1445,7 @@ describe('Datastore', () => {
           data: {
             value: {
               a: 'b',
-              c: [ds.Datastore.int(1), ds.Datastore.int(2), ds.Datastore.int(3)],
+              c: [datastore.int(1), datastore.int(2), datastore.int(3)],
             },
           },
         },

--- a/test/request.ts
+++ b/test/request.ts
@@ -370,6 +370,17 @@ describe('Request', () => {
             found: [
               {
                 entity: {
+                  key: {
+                    partitionId: {
+                      projectId: 'grape-spaceship-123',
+                    },
+                    path: [
+                      {
+                        kind: 'Post',
+                        name: 'post1',
+                      },
+                    ],
+                  },
                   properties: {
                     [propertyName]: {
                       integerValue: largeInt,
@@ -382,7 +393,7 @@ describe('Request', () => {
           });
         };
 
-        const stream = request.createReadStream(key);
+        const stream = request.createReadStream(key, {wrapNumbers: false});
 
         stream
           .on('data', () => {})
@@ -928,6 +939,17 @@ describe('Request', () => {
               entityResults: [
                 {
                   entity: {
+                    key: {
+                      partitionId: {
+                        projectId: 'grape-spaceship-123',
+                      },
+                      path: [
+                        {
+                          kind: 'Post',
+                          name: 'post1',
+                        },
+                      ],
+                    },
                     properties: {
                       [propertyName]: {
                         integerValue: largeInt,
@@ -941,7 +963,7 @@ describe('Request', () => {
           });
         };
 
-        const stream = request.runQueryStream({});
+        const stream = request.runQueryStream({}, {wrapNumbers: false});
 
         stream
           .on('error', (err: Error) => {


### PR DESCRIPTION
BREAKING CHANGE: Datastore doubles and ints are no longer automatically decoded to Javascript Numbers
BREAKING CHANGE: a warning is emitted whenever autoconversion from a Javascript Number to a Datastore Double or Int is used.

As the autoconversion from number to int/double can result in inconsistent db representations, this warns to not use this and that there is some danger to doing so.

Take the double value 4.0. While in Node.js this is consider to be an int, a user specifying 4.0 likely intends for that to be a Datastore Double. The automatic conversion can result in mixed type columns which can make querying entities and their ordering odd, as at this time Datastore entities are ordered by type, then value.

Fixes googleapis/google-cloud-node#7165, googleapis/google-cloud-node#7162, googleapis/google-cloud-node#7164 🦕

