### PR TITLE
fix(cloud-rad): move comments for TSDoc

### DIFF
--- a/src/index-class.ts
+++ b/src/index-class.ts
@@ -78,9 +78,6 @@ export class Index {
     this.id = id.split('/').pop()!;
   }
 
-  get(gaxOptions?: CallOptions): Promise<GetIndexResponse>;
-  get(callback: GetIndexCallback): void;
-  get(gaxOptions: CallOptions, callback: GetIndexCallback): void;
   /**
    * Get an index if it exists.
    *
@@ -91,6 +88,9 @@ export class Index {
    * @param {Index} callback.index The Index instance.
    * @param {object} callback.apiResponse The full API response.
    */
+  get(gaxOptions?: CallOptions): Promise<GetIndexResponse>;
+  get(callback: GetIndexCallback): void;
+  get(gaxOptions: CallOptions, callback: GetIndexCallback): void;
   get(
     gaxOptionsOrCallback?: CallOptions | GetIndexCallback,
     cb?: GetIndexCallback
@@ -105,12 +105,6 @@ export class Index {
     });
   }
 
-  getMetadata(gaxOptions?: CallOptions): Promise<IndexGetMetadataResponse>;
-  getMetadata(callback: IndexGetMetadataCallback): void;
-  getMetadata(
-    gaxOptions: CallOptions,
-    callback: IndexGetMetadataCallback
-  ): void;
   /**
    * Get the metadata of this index.
    *
@@ -120,6 +114,12 @@ export class Index {
    * @param {?error} callback.err An error returned while making this request.
    * @param {object} callback.metadata The metadata.
    */
+  getMetadata(gaxOptions?: CallOptions): Promise<IndexGetMetadataResponse>;
+  getMetadata(callback: IndexGetMetadataCallback): void;
+  getMetadata(
+    gaxOptions: CallOptions,
+    callback: IndexGetMetadataCallback
+  ): void;
   getMetadata(
     gaxOptionsOrCallback?: CallOptions | IndexGetMetadataCallback,
     cb?: IndexGetMetadataCallback

--- a/src/index.ts
+++ b/src/index.ts
@@ -509,8 +509,6 @@ class Datastore extends DatastoreRequest {
     this.auth = new GoogleAuth(this.options);
   }
 
-  export(config: ExportEntitiesConfig): Promise<LongRunningResponse>;
-  export(config: ExportEntitiesConfig, callback: LongRunningCallback): void;
   /**
    * Export entities from this project to a Google Cloud Storage bucket.
    *
@@ -527,6 +525,8 @@ class Datastore extends DatastoreRequest {
    * @param {Operation} callback.operation An operation object that can be used
    *     to check the status of the request.
    */
+  export(config: ExportEntitiesConfig): Promise<LongRunningResponse>;
+  export(config: ExportEntitiesConfig, callback: LongRunningCallback): void;
   export(
     config: ExportEntitiesConfig,
     callback?: LongRunningCallback
@@ -581,9 +581,6 @@ class Datastore extends DatastoreRequest {
     );
   }
 
-  getIndexes(options?: GetIndexesOptions): Promise<GetIndexesResponse>;
-  getIndexes(options: GetIndexesOptions, callback: GetIndexesCallback): void;
-  getIndexes(callback: GetIndexesCallback): void;
   /**
    * Get all of the indexes in this project.
    *
@@ -597,6 +594,9 @@ class Datastore extends DatastoreRequest {
    * @param {object} callback.apiResponse The full API response.
    * @return {void | Promise<GetIndexesResponse>}
    */
+  getIndexes(options?: GetIndexesOptions): Promise<GetIndexesResponse>;
+  getIndexes(options: GetIndexesOptions, callback: GetIndexesCallback): void;
+  getIndexes(callback: GetIndexesCallback): void;
   getIndexes(
     optionsOrCallback?: GetIndexesOptions | GetIndexesCallback,
     cb?: GetIndexesCallback
@@ -687,8 +687,6 @@ class Datastore extends DatastoreRequest {
     return this.auth.getProjectId();
   }
 
-  import(config: ImportEntitiesConfig): Promise<LongRunningResponse>;
-  import(config: ImportEntitiesConfig, callback: LongRunningCallback): void;
   /**
    * Import entities into this project from a remote file.
    *
@@ -705,6 +703,8 @@ class Datastore extends DatastoreRequest {
    * @param {Operation} callback.operation An operation object that can be used
    *     to check the status of the request.
    */
+  import(config: ImportEntitiesConfig): Promise<LongRunningResponse>;
+  import(config: ImportEntitiesConfig, callback: LongRunningCallback): void;
   import(
     config: ImportEntitiesConfig,
     callback?: LongRunningCallback
@@ -769,8 +769,6 @@ class Datastore extends DatastoreRequest {
     return new Index(this, id);
   }
 
-  insert(entities: Entities): Promise<InsertResponse>;
-  insert(entities: Entities, callback: InsertCallback): void;
   /**
    * Maps to {@link Datastore#save}, forcing the method to be `insert`.
    *
@@ -785,6 +783,8 @@ class Datastore extends DatastoreRequest {
    * @param {?error} callback.err An error returned while making this request
    * @param {object} callback.apiResponse The full API response.
    */
+  insert(entities: Entities): Promise<InsertResponse>;
+  insert(entities: Entities, callback: InsertCallback): void;
   insert(
     entities: Entities,
     callback?: InsertCallback
@@ -799,13 +799,6 @@ class Datastore extends DatastoreRequest {
     this.save(entities, callback!);
   }
 
-  save(entities: Entities, gaxOptions?: CallOptions): Promise<SaveResponse>;
-  save(
-    entities: Entities,
-    gaxOptions: CallOptions,
-    callback: SaveCallback
-  ): void;
-  save(entities: Entities, callback: SaveCallback): void;
   /**
    * Insert or update the specified object(s). If a key is incomplete, its
    * associated object is inserted and the original Key object is updated to
@@ -1041,6 +1034,13 @@ class Datastore extends DatastoreRequest {
    * });
    * ```
    */
+  save(entities: Entities, gaxOptions?: CallOptions): Promise<SaveResponse>;
+  save(
+    entities: Entities,
+    gaxOptions: CallOptions,
+    callback: SaveCallback
+  ): void;
+  save(entities: Entities, callback: SaveCallback): void;
   save(
     entities: Entities,
     gaxOptionsOrCallback?: CallOptions | SaveCallback,
@@ -1178,8 +1178,6 @@ class Datastore extends DatastoreRequest {
     );
   }
 
-  update(entities: Entities): Promise<UpdateResponse>;
-  update(entities: Entities, callback: UpdateCallback): void;
   /**
    * Maps to {@link Datastore#save}, forcing the method to be `update`.
    *
@@ -1194,6 +1192,8 @@ class Datastore extends DatastoreRequest {
    * @param {?error} callback.err An error returned while making this request
    * @param {object} callback.apiResponse The full API response.
    */
+  update(entities: Entities): Promise<UpdateResponse>;
+  update(entities: Entities, callback: UpdateCallback): void;
   update(
     entities: Entities,
     callback?: UpdateCallback
@@ -1208,8 +1208,6 @@ class Datastore extends DatastoreRequest {
     this.save(entities, callback!);
   }
 
-  upsert(entities: Entities): Promise<UpsertResponse>;
-  upsert(entities: Entities, callback: UpsertCallback): void;
   /**
    * Maps to {@link Datastore#save}, forcing the method to be `upsert`.
    *
@@ -1224,6 +1222,8 @@ class Datastore extends DatastoreRequest {
    * @param {?error} callback.err An error returned while making this request
    * @param {object} callback.apiResponse The full API response.
    */
+  upsert(entities: Entities): Promise<UpsertResponse>;
+  upsert(entities: Entities, callback: UpsertCallback): void;
   upsert(
     entities: Entities,
     callback?: UpsertCallback
@@ -1450,10 +1450,6 @@ class Datastore extends DatastoreRequest {
   static NO_MORE_RESULTS = 'NO_MORE_RESULTS';
   NO_MORE_RESULTS = Datastore.NO_MORE_RESULTS;
 
-  createQuery(kind?: string): Query;
-  createQuery(kind?: string[]): Query;
-  createQuery(namespace: string, kind: string): Query;
-  createQuery(namespace: string, kind: string[]): Query;
   /**
    * Create a query for the specified kind. See {@link Query} for all
    * of the available methods.
@@ -1472,6 +1468,10 @@ class Datastore extends DatastoreRequest {
    * const query = datastore.createQuery('Company');
    * ```
    */
+  createQuery(kind?: string): Query;
+  createQuery(kind?: string[]): Query;
+  createQuery(namespace: string, kind: string): Query;
+  createQuery(namespace: string, kind: string[]): Query;
   createQuery(
     namespaceOrKind?: string | string[],
     kind?: string | string[]
@@ -1484,9 +1484,6 @@ class Datastore extends DatastoreRequest {
     return new Query(this, namespace, arrify(kind) as string[]);
   }
 
-  key(options: entity.KeyOptions): entity.Key;
-  key(path: PathType[]): entity.Key;
-  key(path: string): entity.Key;
   /**
    * Helper to create a Key object, scoped to the instance's namespace by
    * default.
@@ -1567,6 +1564,9 @@ class Datastore extends DatastoreRequest {
    * const key = datastore.key(['Company', 'Google', 'Employee']);
    * ```
    */
+  key(options: entity.KeyOptions): entity.Key;
+  key(path: PathType[]): entity.Key;
+  key(path: string): entity.Key;
   key(options: string | entity.KeyOptions | PathType[]): entity.Key {
     const keyOptions = is.object(options)
       ? (options as entity.KeyOptions)
@@ -1598,16 +1598,6 @@ class Datastore extends DatastoreRequest {
     return Datastore.isKey(value);
   }
 
-  keyToLegacyUrlSafe(key: entity.Key, locationPrefix?: string): Promise<string>;
-  keyToLegacyUrlSafe(
-    key: entity.Key,
-    callback: KeyToLegacyUrlSafeCallback
-  ): void;
-  keyToLegacyUrlSafe(
-    key: entity.Key,
-    locationPrefix: string,
-    callback: KeyToLegacyUrlSafeCallback
-  ): void;
   /**
    * Helper to create a URL safe key.
    *
@@ -1660,6 +1650,16 @@ class Datastore extends DatastoreRequest {
    * });
    * ```
    */
+  keyToLegacyUrlSafe(key: entity.Key, locationPrefix?: string): Promise<string>;
+  keyToLegacyUrlSafe(
+    key: entity.Key,
+    callback: KeyToLegacyUrlSafeCallback
+  ): void;
+  keyToLegacyUrlSafe(
+    key: entity.Key,
+    locationPrefix: string,
+    callback: KeyToLegacyUrlSafeCallback
+  ): void;
   keyToLegacyUrlSafe(
     key: entity.Key,
     locationPrefixOrCallback?: string | KeyToLegacyUrlSafeCallback,

--- a/src/query.ts
+++ b/src/query.ts
@@ -152,8 +152,6 @@ class Query {
     this.offsetVal = -1;
   }
 
-  filter(property: string, value: {}): Query;
-  filter(property: string, operator: Operator, value: {}): Query;
   /**
    * Datastore allows querying on properties. Supported comparison operators
    * are `=`, `<`, `>`, `<=`, and `>=`. "Not equal" and `IN` operators are
@@ -194,6 +192,8 @@ class Query {
    * const keyQuery = query.filter('__key__', key);
    * ```
    */
+  filter(property: string, value: {}): Query;
+  filter(property: string, operator: Operator, value: {}): Query;
   filter(property: string, operatorOrValue: Operator, value?: {}): Query {
     let operator = operatorOrValue as Operator;
     if (arguments.length === 2) {
@@ -407,9 +407,6 @@ class Query {
     return this;
   }
 
-  run(options?: RunQueryOptions): Promise<RunQueryResponse>;
-  run(options: RunQueryOptions, callback: RunQueryCallback): void;
-  run(callback: RunQueryCallback): void;
   /**
    * Run the query.
    *
@@ -475,6 +472,9 @@ class Query {
    * });
    * ```
    */
+  run(options?: RunQueryOptions): Promise<RunQueryResponse>;
+  run(options: RunQueryOptions, callback: RunQueryCallback): void;
+  run(callback: RunQueryCallback): void;
   run(
     optionsOrCallback?: RunQueryOptions | RunQueryCallback,
     cb?: RunQueryCallback

--- a/src/request.ts
+++ b/src/request.ts
@@ -124,15 +124,6 @@ class DatastoreRequest {
     return entityObject;
   }
 
-  allocateIds(
-    key: entity.Key,
-    options: AllocateIdsOptions | number
-  ): Promise<AllocateIdsResponse>;
-  allocateIds(
-    key: entity.Key,
-    options: AllocateIdsOptions | number,
-    callback: AllocateIdsCallback
-  ): void;
   /**
    * Generate IDs without creating entities.
    *
@@ -207,6 +198,15 @@ class DatastoreRequest {
    * });
    * ```
    */
+  allocateIds(
+    key: entity.Key,
+    options: AllocateIdsOptions | number
+  ): Promise<AllocateIdsResponse>;
+  allocateIds(
+    key: entity.Key,
+    options: AllocateIdsOptions | number,
+    callback: AllocateIdsCallback
+  ): void;
   allocateIds(
     key: entity.Key,
     options: AllocateIdsOptions | number,
@@ -336,13 +336,6 @@ class DatastoreRequest {
     return stream;
   }
 
-  delete(keys: Entities, gaxOptions?: CallOptions): Promise<DeleteResponse>;
-  delete(keys: Entities, callback: DeleteCallback): void;
-  delete(
-    keys: Entities,
-    gaxOptions: CallOptions,
-    callback: DeleteCallback
-  ): void;
   /**
    * Delete all entities identified with the specified key(s).
    *
@@ -393,6 +386,13 @@ class DatastoreRequest {
    * });
    * ```
    */
+  delete(keys: Entities, gaxOptions?: CallOptions): Promise<DeleteResponse>;
+  delete(keys: Entities, callback: DeleteCallback): void;
+  delete(
+    keys: Entities,
+    gaxOptions: CallOptions,
+    callback: DeleteCallback
+  ): void;
   delete(
     keys: entity.Key | entity.Key[],
     gaxOptionsOrCallback?: CallOptions | DeleteCallback,
@@ -428,16 +428,6 @@ class DatastoreRequest {
     );
   }
 
-  get(
-    keys: entity.Key | entity.Key[],
-    options?: CreateReadStreamOptions
-  ): Promise<GetResponse>;
-  get(keys: entity.Key | entity.Key[], callback: GetCallback): void;
-  get(
-    keys: entity.Key | entity.Key[],
-    options: CreateReadStreamOptions,
-    callback: GetCallback
-  ): void;
   /**
    * Retrieve the entities identified with the specified key(s) in the current
    * transaction. Get operations require a valid key to retrieve the
@@ -533,6 +523,16 @@ class DatastoreRequest {
    */
   get(
     keys: entity.Key | entity.Key[],
+    options?: CreateReadStreamOptions
+  ): Promise<GetResponse>;
+  get(keys: entity.Key | entity.Key[], callback: GetCallback): void;
+  get(
+    keys: entity.Key | entity.Key[],
+    options: CreateReadStreamOptions,
+    callback: GetCallback
+  ): void;
+  get(
+    keys: entity.Key | entity.Key[],
     optionsOrCallback?: CreateReadStreamOptions | GetCallback,
     cb?: GetCallback
   ): void | Promise<GetResponse> {
@@ -553,13 +553,6 @@ class DatastoreRequest {
       );
   }
 
-  runQuery(query: Query, options?: RunQueryOptions): Promise<RunQueryResponse>;
-  runQuery(
-    query: Query,
-    options: RunQueryOptions,
-    callback: RunQueryCallback
-  ): void;
-  runQuery(query: Query, callback: RunQueryCallback): void;
   /**
    * Datastore allows you to query entities by kind, filter them by property
    * filters, and sort them by a property name. Projection and pagination are
@@ -659,6 +652,13 @@ class DatastoreRequest {
    * });
    * ```
    */
+  runQuery(query: Query, options?: RunQueryOptions): Promise<RunQueryResponse>;
+  runQuery(
+    query: Query,
+    options: RunQueryOptions,
+    callback: RunQueryCallback
+  ): void;
+  runQuery(query: Query, callback: RunQueryCallback): void;
   runQuery(
     query: Query,
     optionsOrCallback?: RunQueryOptions | RunQueryCallback,
@@ -816,8 +816,6 @@ class DatastoreRequest {
     return stream;
   }
 
-  merge(entities: Entities): Promise<CommitResponse>;
-  merge(entities: Entities, callback: SaveCallback): void;
   /**
    * Merge the specified object(s). If a key is incomplete, its associated object
    * is inserted and the original Key object is updated to contain the generated ID.
@@ -841,6 +839,8 @@ class DatastoreRequest {
    * @param {?error} callback.err An error returned while making this request
    * @param {object} callback.apiResponse The full API response.
    */
+  merge(entities: Entities): Promise<CommitResponse>;
+  merge(entities: Entities, callback: SaveCallback): void;
   merge(
     entities: Entities,
     callback?: SaveCallback
@@ -945,7 +945,6 @@ class DatastoreRequest {
     });
   }
 
-  request_(config: RequestConfig, callback: RequestCallback): void;
   /**
    * Make a request to the API endpoint. Properties to indicate a transactional
    * or non-transactional operation are added automatically.
@@ -959,6 +958,7 @@ class DatastoreRequest {
    *
    * @private
    */
+  request_(config: RequestConfig, callback: RequestCallback): void;
   request_(config: RequestConfig, callback: RequestCallback): void {
     this.prepareGaxRequest_(config, (err: Error, requestFn: Function) => {
       if (err) {

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -98,9 +98,6 @@ class Transaction extends DatastoreRequest {
    *      the final commit request with.
    */
 
-  commit(gaxOptions?: CallOptions): Promise<CommitResponse>;
-  commit(callback: CommitCallback): void;
-  commit(gaxOptions: CallOptions, callback: CommitCallback): void;
   /**
    * Commit the remote transaction and finalize the current transaction
    * instance.
@@ -136,6 +133,9 @@ class Transaction extends DatastoreRequest {
    * });
    * ```
    */
+  commit(gaxOptions?: CallOptions): Promise<CommitResponse>;
+  commit(callback: CommitCallback): void;
+  commit(gaxOptions: CallOptions, callback: CommitCallback): void;
   commit(
     gaxOptionsOrCallback?: CallOptions | CommitCallback,
     cb?: CommitCallback
@@ -261,10 +261,6 @@ class Transaction extends DatastoreRequest {
     );
   }
 
-  createQuery(kind?: string): Query;
-  createQuery(kind?: string[]): Query;
-  createQuery(namespace: string, kind: string): Query;
-  createQuery(namespace: string, kind: string[]): Query;
   /**
    * Create a query for the specified kind. See {module:datastore/query} for all
    * of the available methods.
@@ -330,6 +326,10 @@ class Transaction extends DatastoreRequest {
    * });
    * ```
    */
+  createQuery(kind?: string): Query;
+  createQuery(kind?: string[]): Query;
+  createQuery(namespace: string, kind: string): Query;
+  createQuery(namespace: string, kind: string[]): Query;
   createQuery(
     namespaceOrKind?: string | string[],
     kind?: string | string[]
@@ -410,9 +410,6 @@ class Transaction extends DatastoreRequest {
     this.save(entities);
   }
 
-  rollback(callback: RollbackCallback): void;
-  rollback(gaxOptions?: CallOptions): Promise<RollbackResponse>;
-  rollback(gaxOptions: CallOptions, callback: RollbackCallback): void;
   /**
    * Reverse a transaction remotely and finalize the current transaction
    * instance.
@@ -449,6 +446,9 @@ class Transaction extends DatastoreRequest {
    * });
    * ```
    */
+  rollback(callback: RollbackCallback): void;
+  rollback(gaxOptions?: CallOptions): Promise<RollbackResponse>;
+  rollback(gaxOptions: CallOptions, callback: RollbackCallback): void;
   rollback(
     gaxOptionsOrCallback?: CallOptions | RollbackCallback,
     cb?: RollbackCallback
@@ -471,9 +471,6 @@ class Transaction extends DatastoreRequest {
     );
   }
 
-  run(options?: RunOptions): Promise<RunResponse>;
-  run(callback: RunCallback): void;
-  run(options: RunOptions, callback: RunCallback): void;
   /**
    * Begin a remote transaction. In the callback provided, run your
    * transactional commands.
@@ -526,6 +523,9 @@ class Transaction extends DatastoreRequest {
    * });
    * ```
    */
+  run(options?: RunOptions): Promise<RunResponse>;
+  run(callback: RunCallback): void;
+  run(options: RunOptions, callback: RunCallback): void;
   run(
     optionsOrCallback?: RunOptions | RunCallback,
     cb?: RunCallback


### PR DESCRIPTION
As we move our ref docs to cloud.google.com, we rely on TSDoc rather JSDoc.

TSDoc expects comments before the first overloaded function, we
currently have those on the last function. Those comments don't make
it into the d.ts files. We need to move comments to the first
overloaded function rather than the last one.

Internally b/190631834

Script used: https://github.com/fhinkel/cloud-rad-script/blob/main/moveComments.js
