### PR TITLE
chore: Change the Codeowner to cloud-native-db-dpes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 
 
 # The yoshi-nodejs team is the default owner for nodejs repositories.
-*     @googleapis/yoshi-nodejs @googleapis/firestore-dpe
+*     @googleapis/yoshi-nodejs @googleapis/cloud-native-db-dpes
 
 # The github automation team is the default owner for the auto-approve file.
 .github/auto-approve.yml @googleapis/github-automation

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -9,7 +9,7 @@
   "repo": "googleapis/nodejs-datastore",
   "distribution_name": "@google-cloud/datastore",
   "api_id": "datastore.googleapis.com",
-  "codeowner_team": "@googleapis/firestore-dpe",
+  "codeowner_team": "@googleapis/cloud-native-db-dpes",
   "api_shortname": "datastore",
   "library_type": "GAPIC_COMBO"
 }


### PR DESCRIPTION
Replaced `@googleapis/firestore-dpe` with `@googleapis/cloud-native-db-dpes`