### PR TITLE
fix: Allow filtering null values

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -201,9 +201,13 @@ class Query {
    * const keyQuery = query.filter('__key__', key);
    * ```
    */
-  filter(property: string, value: {}): Query;
-  filter(property: string, operator: Operator, value: {}): Query;
-  filter(property: string, operatorOrValue: Operator, value?: {}): Query {
+  filter(property: string, value: {} | null): Query;
+  filter(property: string, operator: Operator, value: {} | null): Query;
+  filter(
+    property: string,
+    operatorOrValue: Operator,
+    value?: {} | null
+  ): Query {
     let operator = operatorOrValue as Operator;
     if (arguments.length === 2) {
       value = operatorOrValue as {};

--- a/system-test/datastore.ts
+++ b/system-test/datastore.ts
@@ -869,8 +869,19 @@ describe('Datastore', () => {
     });
 
     it('should construct filters by null status', async () => {
-      datastore.createQuery('Character').filter('status', null);
-      datastore.createQuery('Character').filter('status', '=', null);
+      const filtersNoEqual = datastore
+        .createQuery('Character')
+        .filter('status', null)
+        .filters.pop();
+      assert.strictEqual(filtersNoEqual ? filtersNoEqual.val : undefined, null);
+      const filtersWithEqual = datastore
+        .createQuery('Character')
+        .filter('status', '=', null)
+        .filters.pop();
+      assert.strictEqual(
+        filtersWithEqual ? filtersWithEqual.val : undefined,
+        null
+      );
     });
     it('should filter by key', async () => {
       const key = datastore.key(['Book', 'GoT', 'Character', 'Rickard']);

--- a/system-test/datastore.ts
+++ b/system-test/datastore.ts
@@ -869,16 +869,18 @@ describe('Datastore', () => {
     });
 
     it('should construct filters by null status', async () => {
-      const filterNoEqual = datastore
-        .createQuery('Character')
-        .filter('status', null)
-        .filters.pop();
-      assert.strictEqual(filterNoEqual?.val, null);
-      const filterWithEqual = datastore
-        .createQuery('Character')
-        .filter('status', '=', null)
-        .filters.pop();
-      assert.strictEqual(filterWithEqual?.val, null);
+      assert.strictEqual(
+        datastore.createQuery('Character').filter('status', null).filters.pop()
+          ?.val,
+        null
+      );
+      assert.strictEqual(
+        datastore
+          .createQuery('Character')
+          .filter('status', '=', null)
+          .filters.pop()?.val,
+        null
+      );
     });
     it('should filter by key', async () => {
       const key = datastore.key(['Book', 'GoT', 'Character', 'Rickard']);

--- a/system-test/datastore.ts
+++ b/system-test/datastore.ts
@@ -869,17 +869,17 @@ describe('Datastore', () => {
     });
 
     it('should construct filters by null status', async () => {
-      const filtersNoEqual = datastore
+      const filterNoEqual = datastore
         .createQuery('Character')
         .filter('status', null)
         .filters.pop();
-      assert.strictEqual(filtersNoEqual ? filtersNoEqual.val : undefined, null);
-      const filtersWithEqual = datastore
+      assert.strictEqual(filterNoEqual ? filterNoEqual.val : undefined, null);
+      const filterWithEqual = datastore
         .createQuery('Character')
         .filter('status', '=', null)
         .filters.pop();
       assert.strictEqual(
-        filtersWithEqual ? filtersWithEqual.val : undefined,
+        filterWithEqual ? filterWithEqual.val : undefined,
         null
       );
     });

--- a/system-test/datastore.ts
+++ b/system-test/datastore.ts
@@ -868,6 +868,10 @@ describe('Datastore', () => {
       assert.strictEqual(entities.length, characters.length);
     });
 
+    it('should construct filters by null status', async () => {
+      datastore.createQuery('Character').filter('status', null);
+      datastore.createQuery('Character').filter('status', '=', null);
+    });
     it('should filter by key', async () => {
       const key = datastore.key(['Book', 'GoT', 'Character', 'Rickard']);
       const q = datastore

--- a/system-test/datastore.ts
+++ b/system-test/datastore.ts
@@ -873,15 +873,12 @@ describe('Datastore', () => {
         .createQuery('Character')
         .filter('status', null)
         .filters.pop();
-      assert.strictEqual(filterNoEqual ? filterNoEqual.val : undefined, null);
+      assert.strictEqual(filterNoEqual?.val, null);
       const filterWithEqual = datastore
         .createQuery('Character')
         .filter('status', '=', null)
         .filters.pop();
-      assert.strictEqual(
-        filterWithEqual ? filterWithEqual.val : undefined,
-        null
-      );
+      assert.strictEqual(filterWithEqual?.val, null);
     });
     it('should filter by key', async () => {
       const key = datastore.key(['Book', 'GoT', 'Character', 'Rickard']);

--- a/test/query.ts
+++ b/test/query.ts
@@ -163,6 +163,10 @@ describe('Query', () => {
       assert.strictEqual(filter.op, '=');
       assert.strictEqual(filter.val, 'Stephen');
     });
+    it('should accept null as value', () => {
+      new Query(['kind1']).filter('status', null);
+      new Query(['kind1']).filter('status', '=', null);
+    });
   });
 
   describe('hasAncestor', () => {

--- a/test/query.ts
+++ b/test/query.ts
@@ -164,14 +164,14 @@ describe('Query', () => {
       assert.strictEqual(filter.val, 'Stephen');
     });
     it('should accept null as value', () => {
-      const filterNoEqual = new Query(['kind1'])
-        .filter('status', null)
-        .filters.pop();
-      assert.strictEqual(filterNoEqual?.val, null);
-      const filterWithEqual = new Query(['kind1'])
-        .filter('status', '=', null)
-        .filters.pop();
-      assert.strictEqual(filterWithEqual?.val, null);
+      assert.strictEqual(
+        new Query(['kind1']).filter('status', null).filters.pop()?.val,
+        null
+      );
+      assert.strictEqual(
+        new Query(['kind1']).filter('status', '=', null).filters.pop()?.val,
+        null
+      );
     });
   });
 

--- a/test/query.ts
+++ b/test/query.ts
@@ -167,14 +167,11 @@ describe('Query', () => {
       const filterNoEqual = new Query(['kind1'])
         .filter('status', null)
         .filters.pop();
-      assert.strictEqual(filterNoEqual ? filterNoEqual.val : undefined, null);
+      assert.strictEqual(filterNoEqual?.val, null);
       const filterWithEqual = new Query(['kind1'])
         .filter('status', '=', null)
         .filters.pop();
-      assert.strictEqual(
-        filterWithEqual ? filterWithEqual.val : undefined,
-        null
-      );
+      assert.strictEqual(filterWithEqual?.val, null);
     });
   });
 

--- a/test/query.ts
+++ b/test/query.ts
@@ -164,8 +164,17 @@ describe('Query', () => {
       assert.strictEqual(filter.val, 'Stephen');
     });
     it('should accept null as value', () => {
-      new Query(['kind1']).filter('status', null);
-      new Query(['kind1']).filter('status', '=', null);
+      const filterNoEqual = new Query(['kind1'])
+        .filter('status', null)
+        .filters.pop();
+      assert.strictEqual(filterNoEqual ? filterNoEqual.val : undefined, null);
+      const filterWithEqual = new Query(['kind1'])
+        .filter('status', '=', null)
+        .filters.pop();
+      assert.strictEqual(
+        filterWithEqual ? filterWithEqual.val : undefined,
+        null
+      );
     });
   });
 


### PR DESCRIPTION
A user expressed interest in filtering with a null value. Currently this is possible if a null value is provided in a variable, but if a `null` literal is passed into `value` for `.filter` then we get a typescript compiler error. This typescript parameter change will now allow users to not experience the typescript compiler error when trying to filter by null.

Fixes #958