### PR TITLE
chore: remove the blob error workaround

### DIFF
--- a/src/entity.ts
+++ b/src/entity.ts
@@ -657,10 +657,7 @@ export namespace entity {
     }
 
     if (value instanceof Buffer) {
-      // Convert the buffer to a base 64 string to workaround a bug of
-      // protobufs encoding empty buffer.
-      // See https://github.com/googleapis/nodejs-datastore/issues/755
-      valueProto.blobValue = value.toString('base64');
+      valueProto.blobValue = value;
       return valueProto;
     }
 

--- a/system-test/datastore.ts
+++ b/system-test/datastore.ts
@@ -543,6 +543,19 @@ describe('Datastore', () => {
       await datastore.delete(personKey);
     });
 
+    it('should save with an empty buffer', async () => {
+      const key = datastore.key(['TEST']);
+      const result = await datastore.save({
+        key: key,
+        data: {
+          name: 'test',
+          blob: Buffer.from([]),
+        },
+      });
+      const mutationResult = result.pop()?.mutationResults?.pop();
+      assert.strictEqual(mutationResult?.key?.path?.pop()?.kind, 'TEST');
+    });
+
     describe('entity types', () => {
       it('should save and decode an int', async () => {
         const integerValue = 2015;

--- a/test/entity.ts
+++ b/test/entity.ts
@@ -849,7 +849,7 @@ describe('entity', () => {
       const value = Buffer.from('Hi');
 
       const expectedValueProto = {
-        blobValue: value.toString('base64'),
+        blobValue: value,
       };
 
       assert.deepStrictEqual(entity.encodeValue(value), expectedValueProto);


### PR DESCRIPTION
An error with code 3 was thrown when the test code was run before the workaround was added and before the proto changes were made. Now that the proto changes have been made, the workaround is no longer required so it is removed in this commit.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-datastore/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #755  🦕
