### PR TITLE
Change to try to ignore __key__ as it is redundant

### DIFF
--- a/src/entity.ts
+++ b/src/entity.ts
@@ -416,6 +416,10 @@ export namespace entity {
       });
     }
 
+    isKey() {
+      return true;
+    }
+
     /**
      * Access the `serialized` property for a library-compatible way to re-use a
      * key.
@@ -457,7 +461,11 @@ export namespace entity {
    * @returns {boolean}
    */
   export function isDsKey(value?: {}): value is entity.Key {
-    return value instanceof entity.Key;
+    const valueToCheck = value as Key;
+    if (value) {
+      return value && 'isKey' in value && valueToCheck.isKey();
+    }
+    return false;
   }
 
   /**

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -416,10 +416,6 @@ export namespace entity {
       });
     }
 
-    isKey() {
-      return true;
-    }
-
     /**
      * Access the `serialized` property for a library-compatible way to re-use a
      * key.
@@ -461,11 +457,7 @@ export namespace entity {
    * @returns {boolean}
    */
   export function isDsKey(value?: {}): value is entity.Key {
-    const valueToCheck = value as Key;
-    if (value) {
-      return value && 'isKey' in value && valueToCheck.isKey();
-    }
-    return false;
+    return value instanceof entity.Key;
   }
 
   /**

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -84,14 +84,7 @@ export class PropertyFilter extends EntityFilter implements IFilter {
   }
 
   private encodedValue(): any {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let value: any = {};
-    if (this.name === '__key__') {
-      value.keyValue = entity.keyToKeyProto(this.val);
-    } else {
-      value = entity.encodeValue(this.val, this.name);
-    }
-    return value;
+    return entity.encodeValue(this.val, this.name);
   }
 
   /**


### PR DESCRIPTION
This change matches the change shown in another PR, but the test cases won’t allow for the new change. There must be some edge cases that haven’t been considered here.