### PR TITLE
fix: Allow user to set custom endpoints

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -507,7 +507,8 @@ class Datastore extends DatastoreRequest {
     const isUsingEmulator =
       this.baseUrl_ &&
       (this.baseUrl_.includes('localhost') ||
-        this.baseUrl_.includes('127.0.0.1'));
+        this.baseUrl_.includes('127.0.0.1') ||
+        this.baseUrl_.includes('::1'));
     if (this.customEndpoint_ && isUsingEmulator) {
       this.options.sslCreds ??= grpc.credentials.createInsecure();
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -504,8 +504,12 @@ class Datastore extends DatastoreRequest {
       },
       options
     );
-    if (this.customEndpoint_) {
-      this.options.sslCreds = grpc.credentials.createInsecure();
+    const isUsingEmulator =
+      this.baseUrl_ &&
+      (this.baseUrl_.includes('localhost') ||
+        this.baseUrl_.includes('127.0.0.1'));
+    if (this.customEndpoint_ && isUsingEmulator) {
+      this.options.sslCreds ??= grpc.credentials.createInsecure();
     }
 
     this.auth = new GoogleAuth(this.options);

--- a/system-test/datastore.ts
+++ b/system-test/datastore.ts
@@ -1362,13 +1362,14 @@ describe('Datastore', () => {
   });
 
   describe('using a custom endpoint', () => {
-    it('should complete a request when using a custom endpoint', async () => {
+    it('should complete a request when using the default endpoint as a custom endpoint', async () => {
       const customDatastore = new Datastore({
         namespace: `${Date.now()}`,
         apiEndpoint: 'datastore.googleapis.com',
       });
       const query = customDatastore.createQuery('Kind').select('__key__');
       const [entities] = await customDatastore.runQuery(query);
+      assert.strictEqual(entities.length, 0);
     });
   });
 });

--- a/system-test/datastore.ts
+++ b/system-test/datastore.ts
@@ -1360,4 +1360,15 @@ describe('Datastore', () => {
       await importOperation.cancel();
     });
   });
+
+  describe('using a custom endpoint', () => {
+    it('should complete a request when using a custom endpoint', async () => {
+      const customDatastore = new Datastore({
+        namespace: `${Date.now()}`,
+        apiEndpoint: 'datastore.googleapis.com',
+      });
+      const query = customDatastore.createQuery('Kind').select('__key__');
+      const [entities] = await customDatastore.runQuery(query);
+    });
+  });
 });

--- a/test/index.ts
+++ b/test/index.ts
@@ -151,7 +151,7 @@ describe('Datastore', () => {
 
   const OPTIONS = {
     projectId: PROJECT_ID,
-    apiEndpoint: 'http://endpoint',
+    apiEndpoint: 'http://localhost',
     credentials: {},
     keyFilename: 'key/file',
     email: 'email',
@@ -289,14 +289,7 @@ describe('Datastore', () => {
       assert.strictEqual((datastore.options as any).port, port);
     });
 
-    it('should set grpc ssl credentials if custom endpoint', () => {
-      const determineBaseUrl_ = Datastore.prototype.determineBaseUrl_;
-
-      Datastore.prototype.determineBaseUrl_ = function () {
-        Datastore.prototype.determineBaseUrl_ = determineBaseUrl_;
-        this.customEndpoint_ = true;
-      };
-
+    it('should set grpc ssl credentials if localhost custom endpoint', () => {
       const fakeInsecureCreds = {};
       createInsecureOverride = () => {
         return fakeInsecureCreds;


### PR DESCRIPTION
This change allows the user to set a custom endpoint when creating the client and it will work with the backend the way it is supposed to. It also ensures that we can still work with the emulator using the client.
