### PR TITLE
test: Extend the sleep time to allow save to work

### DIFF
--- a/system-test/datastore.ts
+++ b/system-test/datastore.ts
@@ -332,7 +332,7 @@ describe('Datastore', () => {
       const path = ['Post', 'post1'];
       const postKey = datastore.key(path);
       await datastore.save({key: postKey, data: post});
-      await sleep(1000);
+      await sleep(10000);
       const savedTime = Date.now();
       await sleep(1000);
       // Save new post2 data, but then verify the timestamp read has post1 data

--- a/system-test/datastore.ts
+++ b/system-test/datastore.ts
@@ -499,41 +499,6 @@ async.each(
           const path = ['Post', 'post1'];
           const postKey = datastore.key(path);
           await datastore.save({key: postKey, data: post});
-          await sleep(1000);
-          const savedTime = Date.now();
-          await sleep(1000);
-          // Save new post2 data, but then verify the timestamp read has post1 data
-          await datastore.save({key: postKey, data: post2});
-          const [entity] = await datastore.get(postKey, {readTime: savedTime});
-          assert.deepStrictEqual(entity[datastore.KEY], postKey);
-          const [entityNoOptions] = await datastore.get(postKey);
-          assert.deepStrictEqual(entityNoOptions[datastore.KEY], postKey);
-          delete entity[datastore.KEY];
-          assert.deepStrictEqual(entity, post);
-          delete entityNoOptions[datastore.KEY];
-          assert.deepStrictEqual(entityNoOptions, post2);
-          await datastore.delete(postKey);
-        });
-        it('should save/get/delete from a snapshot', async () => {
-          function sleep(ms: number) {
-            return new Promise(resolve => setTimeout(resolve, ms));
-          }
-          const post2 = {
-            title: 'Another way to make pizza',
-            tags: ['pizza', 'grill'],
-            publishedAt: new Date(),
-            author: 'Silvano',
-            isDraft: false,
-            wordCount: 400,
-            rating: 5.0,
-            likes: null,
-            metadata: {
-              views: 100,
-            },
-          };
-          const path = ['Post', 'post1'];
-          const postKey = datastore.key(path);
-          await datastore.save({key: postKey, data: post});
           await sleep(10000);
           const savedTime = Date.now();
           await sleep(1000);

--- a/system-test/datastore.ts
+++ b/system-test/datastore.ts
@@ -514,41 +514,41 @@ async.each(
           assert.deepStrictEqual(entityNoOptions, post2);
           await datastore.delete(postKey);
         });
-    it('should save/get/delete from a snapshot', async () => {
-      function sleep(ms: number) {
-        return new Promise(resolve => setTimeout(resolve, ms));
-      }
-      const post2 = {
-        title: 'Another way to make pizza',
-        tags: ['pizza', 'grill'],
-        publishedAt: new Date(),
-        author: 'Silvano',
-        isDraft: false,
-        wordCount: 400,
-        rating: 5.0,
-        likes: null,
-        metadata: {
-          views: 100,
-        },
-      };
-      const path = ['Post', 'post1'];
-      const postKey = datastore.key(path);
-      await datastore.save({key: postKey, data: post});
-      await sleep(10000);
-      const savedTime = Date.now();
-      await sleep(1000);
-      // Save new post2 data, but then verify the timestamp read has post1 data
-      await datastore.save({key: postKey, data: post2});
-      const [entity] = await datastore.get(postKey, {readTime: savedTime});
-      assert.deepStrictEqual(entity[datastore.KEY], postKey);
-      const [entityNoOptions] = await datastore.get(postKey);
-      assert.deepStrictEqual(entityNoOptions[datastore.KEY], postKey);
-      delete entity[datastore.KEY];
-      assert.deepStrictEqual(entity, post);
-      delete entityNoOptions[datastore.KEY];
-      assert.deepStrictEqual(entityNoOptions, post2);
-      await datastore.delete(postKey);
-    });
+        it('should save/get/delete from a snapshot', async () => {
+          function sleep(ms: number) {
+            return new Promise(resolve => setTimeout(resolve, ms));
+          }
+          const post2 = {
+            title: 'Another way to make pizza',
+            tags: ['pizza', 'grill'],
+            publishedAt: new Date(),
+            author: 'Silvano',
+            isDraft: false,
+            wordCount: 400,
+            rating: 5.0,
+            likes: null,
+            metadata: {
+              views: 100,
+            },
+          };
+          const path = ['Post', 'post1'];
+          const postKey = datastore.key(path);
+          await datastore.save({key: postKey, data: post});
+          await sleep(10000);
+          const savedTime = Date.now();
+          await sleep(1000);
+          // Save new post2 data, but then verify the timestamp read has post1 data
+          await datastore.save({key: postKey, data: post2});
+          const [entity] = await datastore.get(postKey, {readTime: savedTime});
+          assert.deepStrictEqual(entity[datastore.KEY], postKey);
+          const [entityNoOptions] = await datastore.get(postKey);
+          assert.deepStrictEqual(entityNoOptions[datastore.KEY], postKey);
+          delete entity[datastore.KEY];
+          assert.deepStrictEqual(entity, post);
+          delete entityNoOptions[datastore.KEY];
+          assert.deepStrictEqual(entityNoOptions, post2);
+          await datastore.delete(postKey);
+        });
 
         it('should save/get/delete with a numeric key id', async () => {
           const postKey = datastore.key(['Post', 123456789]);


### PR DESCRIPTION
The problem here is that on [this line](https://github.com/googleapis/nodejs-datastore/blob/e7c3aaf665ebae5a91fb692bb0af54717e5ea587/system-test/datastore.ts#L340) the entity gets assigned to undefined probably because when the server checks the `savedTime` at the `readTime` then it doesn't see any data. This could happen if the server's clock is ahead by more than a second in which case a second is not long enough to sleep which may happen occasionally. Ten seconds should be long enough to prevent any sort of flakey test from occurring.

The sleep time should be increased to allow the save time to vary significantly from the variable savedTime so that any time difference between the client and the server’s clock is negligible compared to the sleep time.

Fixes #1123
