### PR TITLE
fix: reduce latency by getting project id locally

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -1007,8 +1007,13 @@ class DatastoreRequest {
         transaction: this.id,
       };
     }
-
-    datastore.auth.getProjectId((err, projectId) => {
+    const datastoreProjectId = datastore?.options?.projectId;
+    if (datastoreProjectId) {
+      makeGapicCall(null, datastoreProjectId);
+    } else {
+      datastore.auth.getProjectId(makeGapicCall);
+    }
+    function makeGapicCall(err: any, projectId: any){
       if (err) {
         callback!(err);
         return;
@@ -1016,8 +1021,8 @@ class DatastoreRequest {
       const clientName = config.client;
       if (!datastore.clients_.has(clientName)) {
         datastore.clients_.set(
-          clientName,
-          new gapic.v1[clientName](datastore.options)
+            clientName,
+            new gapic.v1[clientName](datastore.options)
         );
       }
       const gaxClient = datastore.clients_.get(clientName);
@@ -1029,7 +1034,7 @@ class DatastoreRequest {
       });
       const requestFn = gaxClient![method].bind(gaxClient, reqOpts, gaxOpts);
       callback(null, requestFn);
-    });
+    }
   }
 
   /**

--- a/src/request.ts
+++ b/src/request.ts
@@ -1007,6 +1007,7 @@ class DatastoreRequest {
         transaction: this.id,
       };
     }
+    
     datastore.auth.getProjectId((err, projectId) => {
       if (err) {
         callback!(err);

--- a/src/request.ts
+++ b/src/request.ts
@@ -1034,7 +1034,7 @@ class DatastoreRequest {
       });
       const requestFn = gaxClient![method].bind(gaxClient, reqOpts, gaxOpts);
       callback(null, requestFn);
-    }
+    });
   }
 
   /**

--- a/src/request.ts
+++ b/src/request.ts
@@ -1013,7 +1013,7 @@ class DatastoreRequest {
     } else {
       datastore.auth.getProjectId(makeGapicCall);
     }
-    function makeGapicCall(err: any, projectId: any){
+    function makeGapicCall(err: any, projectId: any) {
       if (err) {
         callback!(err);
         return;
@@ -1021,8 +1021,8 @@ class DatastoreRequest {
       const clientName = config.client;
       if (!datastore.clients_.has(clientName)) {
         datastore.clients_.set(
-            clientName,
-            new gapic.v1[clientName](datastore.options)
+          clientName,
+          new gapic.v1[clientName](datastore.options)
         );
       }
       const gaxClient = datastore.clients_.get(clientName);

--- a/src/request.ts
+++ b/src/request.ts
@@ -1007,7 +1007,7 @@ class DatastoreRequest {
         transaction: this.id,
       };
     }
-    
+
     datastore.auth.getProjectId((err, projectId) => {
       if (err) {
         callback!(err);

--- a/src/request.ts
+++ b/src/request.ts
@@ -1007,13 +1007,7 @@ class DatastoreRequest {
         transaction: this.id,
       };
     }
-    const datastoreProjectId = datastore?.options?.projectId;
-    if (datastoreProjectId) {
-      makeGapicCall(null, datastoreProjectId);
-    } else {
-      datastore.auth.getProjectId(makeGapicCall);
-    }
-    function makeGapicCall(err: any, projectId: any) {
+    datastore.auth.getProjectId((err, projectId) => {
       if (err) {
         callback!(err);
         return;

--- a/test/gapic-mocks/commit.ts
+++ b/test/gapic-mocks/commit.ts
@@ -1,0 +1,31 @@
+import {before, describe} from 'mocha';
+import * as ds from '../../src';
+
+describe('Commit', () => {
+  let Datastore: typeof ds.Datastore;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let datastore: any;
+
+  const PROJECT_ID = 'project-id';
+  const NAMESPACE = 'namespace';
+
+  before(() => {
+    const clientName = 'DatastoreClient';
+    const options = {
+      projectId: PROJECT_ID,
+      namespace: NAMESPACE,
+    };
+    datastore = new Datastore(options);
+    // By default, datastore.clients_ is an empty map.
+    // To mock out commit we need the map to contain the Gapic data client.
+    // Normally a call to the data client through the datastore object would initialize it.
+    // We don't want to make this call because it would make a grpc request.
+    // So we just add the data client to the map.
+    const gapic = Object.freeze({
+      v1: require('../src/v1'),
+    });
+    datastore.clients_.set(clientName, new gapic.v1[clientName](options));
+    // Mock out commit and just have it pass back the information passed into it through the callback.
+    // This way we can easily use assertion checks to see what reached the gapic layer.
+  });
+});

--- a/test/gapic-mocks/commit.ts
+++ b/test/gapic-mocks/commit.ts
@@ -70,12 +70,12 @@ describe('Commit', () => {
 
   it('should not experience latency when fetching the project', async () => {
     const startTime = Date.now();
-    setCommitComparison(() => {
-      const endTime = Date.now();
-      const callTime = endTime - startTime;
-      // Testing locally reveals callTime is usually about 1.
-      assert(callTime < 100);
-    });
+    setCommitComparison(() => {});
     await datastore.save([]);
+    const endTime = Date.now();
+    const callTime = endTime - startTime;
+    console.log(`call time: ${callTime}`);
+    // Testing locally reveals callTime is usually about 1.
+    assert(callTime < 100);
   });
 });

--- a/test/gapic-mocks/commit.ts
+++ b/test/gapic-mocks/commit.ts
@@ -1,3 +1,17 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import * as assert from 'assert';
 import {before, describe} from 'mocha';
 import * as ds from '../../src';


### PR DESCRIPTION
This PR includes work to reduce latency in a client library call discussed in https://github.com/googleapis/nodejs-datastore/issues/1110. This change does not solve the latency issue completely because there is additional latency in the Gapic/Gax/Grpc layer for these calls.

The latency is caused by a call to the auth library to get the projectId (https://github.com/googleapis/nodejs-datastore/blob/0d8b7153fc156a4b55e965f39161bd5c19bffff6/src/request.ts#L1011). This particular call takes a long time to complete and the amount of time it takes to run all of the other client library code for the call up to the Gapic layer is negligible. In Bigtable, this latency issue is handled by skipping the call to auth and using the projectId supplied by the user here (https://github.com/googleapis/nodejs-bigtable/blob/0126a0ea1e4b6a845acb4e5600ddb3082443d310/src/index.ts#L925). In nodejs-datastore, the same thing can be done where the projectId supplied by the user is used instead of making a call to auth to get the projectId. This PR implements the change that gets the projectId supplied by the user.
