### PR TITLE
fix: Allow users to set environment variable to connect to emulator running on docker

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -505,7 +505,14 @@ class Datastore extends DatastoreRequest {
       },
       options
     );
-    if (this.customEndpoint_ && process.env.DATASTORE_EMULATOR_HOST) {
+    const isUsingLocalhost =
+      this.baseUrl_ &&
+      (this.baseUrl_.includes('localhost') ||
+        this.baseUrl_.includes('127.0.0.1') ||
+        this.baseUrl_.includes('::1'));
+    const isEmulatorVariableSet = process.env.DATASTORE_EMULATOR_HOST;
+    const isUsingEmulator = isUsingLocalhost || isEmulatorVariableSet;
+    if (this.customEndpoint_ && isUsingEmulator) {
       this.options.sslCreds ??= grpc.credentials.createInsecure();
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -505,7 +505,12 @@ class Datastore extends DatastoreRequest {
       },
       options
     );
-    if (this.customEndpoint_ && process.env.DATASTORE_EMULATOR_HOST) {
+    const isUsingEmulator =
+      this.baseUrl_ &&
+      (this.baseUrl_.includes('localhost') ||
+        this.baseUrl_.includes('127.0.0.1') ||
+        this.baseUrl_.includes('::1'));
+    if (this.customEndpoint_ && isUsingEmulator) {
       this.options.sslCreds ??= grpc.credentials.createInsecure();
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -505,12 +505,7 @@ class Datastore extends DatastoreRequest {
       },
       options
     );
-    const isUsingEmulator =
-      this.baseUrl_ &&
-      (this.baseUrl_.includes('localhost') ||
-        this.baseUrl_.includes('127.0.0.1') ||
-        this.baseUrl_.includes('::1'));
-    if (this.customEndpoint_ && isUsingEmulator) {
+    if (this.customEndpoint_ && process.env.DATASTORE_EMULATOR_HOST) {
       this.options.sslCreds ??= grpc.credentials.createInsecure();
     }
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -318,13 +318,14 @@ describe('Datastore', () => {
       });
 
       describe('without DATASTORE_EMULATOR_HOST environment variable set', () => {
+        const apiEndpoint = OPTIONS.apiEndpoint;
         beforeEach(() => {
           delete process.env.DATASTORE_EMULATOR_HOST;
         });
 
         it('should use ssl credentials provided', () => {
           const options = {
-            apiEndpoint: OPTIONS.apiEndpoint,
+            apiEndpoint,
             sslCreds,
           };
           const datastore = new Datastore(options);
@@ -333,7 +334,7 @@ describe('Datastore', () => {
 
         it('should not set ssl credentials when ssl credentials are not provided', () => {
           const datastore = new Datastore({
-            apiEndpoint: 'http://localhost',
+            apiEndpoint,
           });
           assert.strictEqual(datastore.options.sslCreds, undefined);
         });
@@ -344,14 +345,14 @@ describe('Datastore', () => {
         });
 
         describe('with DATASTORE_EMULATOR_HOST set to localhost', () => {
-          const host = 'http://localhost:8080';
+          const apiEndpoint = 'http://localhost:8080';
           beforeEach(() => {
-            setHost(host);
+            setHost(apiEndpoint);
           });
 
           it('should use ssl credentials provided', () => {
             const datastore = new Datastore({
-              apiEndpoint: host,
+              apiEndpoint,
               sslCreds,
             });
             assert.strictEqual(datastore.options.sslCreds, sslCreds);
@@ -359,21 +360,21 @@ describe('Datastore', () => {
 
           it('should use insecure ssl credentials when ssl credentials are not provided', () => {
             const datastore = new Datastore({
-              apiEndpoint: host,
+              apiEndpoint,
             });
             assert.strictEqual(datastore.options.sslCreds, fakeInsecureCreds);
           });
         });
 
         describe('with DATASTORE_EMULATOR_HOST set to remote host', () => {
-          const host = 'http://remote:8080';
+          const apiEndpoint = 'http://remote:8080';
           beforeEach(() => {
-            setHost('http://some-remote-host');
+            setHost(apiEndpoint);
           });
 
           it('should use ssl credentials provided', () => {
             const datastore = new Datastore({
-              apiEndpoint: host,
+              apiEndpoint,
               sslCreds,
             });
             assert.strictEqual(datastore.options.sslCreds, sslCreds);
@@ -381,7 +382,7 @@ describe('Datastore', () => {
 
           it('should use insecure ssl credentials when ssl credentials are not provided', () => {
             const datastore = new Datastore({
-              apiEndpoint: host,
+              apiEndpoint,
             });
             assert.strictEqual(datastore.options.sslCreds, fakeInsecureCreds);
           });

--- a/test/index.ts
+++ b/test/index.ts
@@ -203,10 +203,6 @@ describe('Datastore', () => {
   });
 
   describe('instantiation', () => {
-    function setHost(host: string) {
-      process.env.DATASTORE_EMULATOR_HOST = host;
-    }
-
     it('should initialize an empty Client map', () => {
       assert(datastore.clients_ instanceof Map);
       assert.strictEqual(datastore.clients_.size, 0);
@@ -293,7 +289,7 @@ describe('Datastore', () => {
       assert.strictEqual((datastore.options as any).port, port);
     });
 
-    it('should set ssl credentials if using a custom endpoint', () => {
+    it('should set grpc ssl credentials if localhost custom endpoint', () => {
       const fakeInsecureCreds = {};
       createInsecureOverride = () => {
         return fakeInsecureCreds;
@@ -305,6 +301,10 @@ describe('Datastore', () => {
     });
 
     describe('checking ssl credentials are set correctly with custom endpoints', () => {
+      function setHost(host: string) {
+        process.env.DATASTORE_EMULATOR_HOST = host;
+      }
+      
       const sslCreds = gax.grpc.ChannelCredentials.createSsl();
       const fakeInsecureCreds = {
         insecureCredProperty: 'insecureCredPropertyValue',

--- a/test/index.ts
+++ b/test/index.ts
@@ -293,8 +293,7 @@ describe('Datastore', () => {
       assert.strictEqual((datastore.options as any).port, port);
     });
 
-    it('should set ssl credentials if using a custom endpoint and an emulator', () => {
-      setHost(OPTIONS.apiEndpoint);
+    it('should set ssl credentials if using a custom endpoint', () => {
       const fakeInsecureCreds = {};
       createInsecureOverride = () => {
         return fakeInsecureCreds;
@@ -318,25 +317,43 @@ describe('Datastore', () => {
       });
 
       describe('without DATASTORE_EMULATOR_HOST environment variable set', () => {
-        const apiEndpoint = OPTIONS.apiEndpoint;
         beforeEach(() => {
           delete process.env.DATASTORE_EMULATOR_HOST;
         });
 
-        it('should use ssl credentials provided', () => {
-          const options = {
-            apiEndpoint,
-            sslCreds,
-          };
-          const datastore = new Datastore(options);
-          assert.strictEqual(datastore.options.sslCreds, sslCreds);
-        });
-
-        it('should not set ssl credentials when ssl credentials are not provided', () => {
-          const datastore = new Datastore({
-            apiEndpoint,
+        describe('using a localhost endpoint', () => {
+          const apiEndpoint = 'http://localhost:8080';
+          it('should use ssl credentials provided', () => {
+            const options = {
+              apiEndpoint,
+              sslCreds,
+            };
+            const datastore = new Datastore(options);
+            assert.strictEqual(datastore.options.sslCreds, sslCreds);
           });
-          assert.strictEqual(datastore.options.sslCreds, undefined);
+          it('should use insecure ssl credentials when ssl credentials are not provided', () => {
+            const datastore = new Datastore({
+              apiEndpoint,
+            });
+            assert.strictEqual(datastore.options.sslCreds, fakeInsecureCreds);
+          });
+        });
+        describe('using a remote endpoint', () => {
+          const apiEndpoint = 'http://remote:8080';
+          it('should use ssl credentials provided', () => {
+            const options = {
+              apiEndpoint,
+              sslCreds,
+            };
+            const datastore = new Datastore(options);
+            assert.strictEqual(datastore.options.sslCreds, sslCreds);
+          });
+          it('should not set ssl credentials when ssl credentials are not provided', () => {
+            const datastore = new Datastore({
+              apiEndpoint,
+            });
+            assert.strictEqual(datastore.options.sslCreds, undefined);
+          });
         });
       });
       describe('with DATASTORE_EMULATOR_HOST environment variable set', () => {

--- a/test/index.ts
+++ b/test/index.ts
@@ -304,7 +304,7 @@ describe('Datastore', () => {
       function setHost(host: string) {
         process.env.DATASTORE_EMULATOR_HOST = host;
       }
-      
+
       const sslCreds = gax.grpc.ChannelCredentials.createSsl();
       const fakeInsecureCreds = {
         insecureCredProperty: 'insecureCredPropertyValue',
@@ -324,6 +324,7 @@ describe('Datastore', () => {
         describe('using a localhost endpoint', () => {
           const apiEndpoint = 'http://localhost:8080';
           it('should use ssl credentials provided', () => {
+            // SSL credentials provided in the constructor should always be used.
             const options = {
               apiEndpoint,
               sslCreds,
@@ -332,6 +333,8 @@ describe('Datastore', () => {
             assert.strictEqual(datastore.options.sslCreds, sslCreds);
           });
           it('should use insecure ssl credentials when ssl credentials are not provided', () => {
+            // When using a localhost endpoint it is assumed that the emulator is being used.
+            // Therefore, sslCreds should be set to insecure credentials to skip authentication.
             const datastore = new Datastore({
               apiEndpoint,
             });
@@ -341,6 +344,7 @@ describe('Datastore', () => {
         describe('using a remote endpoint', () => {
           const apiEndpoint = 'http://remote:8080';
           it('should use ssl credentials provided', () => {
+            // SSL credentials provided in the constructor should always be used.
             const options = {
               apiEndpoint,
               sslCreds,
@@ -349,6 +353,9 @@ describe('Datastore', () => {
             assert.strictEqual(datastore.options.sslCreds, sslCreds);
           });
           it('should not set ssl credentials when ssl credentials are not provided', () => {
+            // When using a remote endpoint without DATASTORE_EMULATOR_HOST set,
+            // it is assumed that the emulator is not being used.
+            // This test captures the case where users use a regional endpoint.
             const datastore = new Datastore({
               apiEndpoint,
             });
@@ -368,6 +375,7 @@ describe('Datastore', () => {
           });
 
           it('should use ssl credentials provided', () => {
+            // SSL credentials provided in the constructor should always be used.
             const datastore = new Datastore({
               apiEndpoint,
               sslCreds,
@@ -376,6 +384,8 @@ describe('Datastore', () => {
           });
 
           it('should use insecure ssl credentials when ssl credentials are not provided', () => {
+            // When DATASTORE_EMULATOR_HOST is set it is assumed that the emulator is being used.
+            // Therefore, sslCreds should be set to insecure credentials to skip authentication.
             const datastore = new Datastore({
               apiEndpoint,
             });
@@ -390,6 +400,7 @@ describe('Datastore', () => {
           });
 
           it('should use ssl credentials provided', () => {
+            // SSL credentials provided in the constructor should always be used.
             const datastore = new Datastore({
               apiEndpoint,
               sslCreds,
@@ -398,6 +409,8 @@ describe('Datastore', () => {
           });
 
           it('should use insecure ssl credentials when ssl credentials are not provided', () => {
+            // When DATASTORE_EMULATOR_HOST is set it is assumed that the emulator is being used.
+            // Therefore, sslCreds should be set to insecure credentials to skip authentication.
             const datastore = new Datastore({
               apiEndpoint,
             });


### PR DESCRIPTION
Fixes https://github.com/googleapis/nodejs-datastore/issues/1119

**Summary:**

Originally, https://github.com/googleapis/nodejs-datastore/pull/1101/files was merged to support users who wanted to pass in a custom regional endpoint to use a datastore service hosted at a different address than the default endpoint. Before PR 1101 the code assumed that if a custom endpoint was provided then the emulator was being used so insecure credentials should be set so authentication can be skipped, but for users using regional endpoints this does not work. Users using regional endpoints still need authentication so a change in PR 1101 was introduced to set insecure credentials and skip authentication only if the provided endpoint was localhost.

After the PR was merged, users were affected who were using the emulator on a docker service. This is because after PR 1101 was merged the code is checking to see if the custom endpoint provided is localhost, realizing that it is not and so is not setting insecure authentication credentials like it was before and is not skipping authentication. If users are using the emulator on docker, they should at least be able to set DATASTORE_EMULATOR_HOST to indicate that they want to use the emulator so that authentication can be skipped and they can use the emulator.

**Changes:**

This PR allows the code to assume that the user is using the emulator if the endpoint provided is localhost or the DATASTORE_EMULATOR_HOST environment variable is set. The reason we cannot just check to see if the DATASTORE_EMULATOR_HOST variable is set is because the user might not be using this environment variable when using the emulator and instead might be passing in the emulator address in apiEndpoint as instructed by the following documentation:
https://github.com/googleapis/nodejs-datastore/blob/6f6acfdae731c14c90a6094147e2cb0fe3bb61f6/src/index.ts#L153-L155. It is important to cover the case where the user is using the emulator, but passing the emulator address into the constructor.

**Test cases failing before source code changes:**

checking ssl credentials are set correctly with custom endpoints
    with DATASTORE_EMULATOR_HOST environment variable set
        with DATASTORE_EMULATOR_HOST set to remote host
            should use insecure ssl credentials when ssl credentials are not provided:

**Remaining limitations:**

With this change there are still two cases where users will not have their preferred experience.

1. When the user is running an emulator on a docker service and they are not setting the DATASTORE_EMULATOR_HOST environment variable and instead passing apiEndpoint into the constructor then their code will not skip authentication and will not connect to the emulator. This means users running the emulator on docker must connect to the emulator by setting DATASTORE_EMULATOR_HOST. There is no way to avoid this limitation because we want to support regional endpoints and there is no way to detect the difference between a regional endpoint passed in and an endpoint for a host running an emulator on docker. This limitation existed before the change in this PR, but not before PR 1101.
2. This PR introduces a problem for users that set DATASTORE_EMULATOR_HOST and wish to use a regional endpoint. Users using a regional endpoint should normally not be setting DATASTORE_EMULATOR_HOST environment variable, but if they are then their calls to the regional endpoint will not work. Since we have no way to distinguish a regional endpoint from a docker endpoint running the emulator, we cannot make all users happy who supply a custom remote endpoint and provide the DATASTORE_EMULATOR_HOST environment variable. For this case, we either set insecure credentials and skip authentication in this case introducing this problem or we don’t skip authentication and don’t solve https://github.com/googleapis/nodejs-datastore/issues/1119.
