### PR TITLE
fix: Make aggregation query requests run properly inside a transaction

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -1000,7 +1000,7 @@ class DatastoreRequest {
       reqOpts.transaction = this.id;
     }
 
-    if (isTransaction && (method === 'lookup' || method === 'runQuery')) {
+    if (isTransaction && (method === 'lookup' || method === 'runQuery' || method === 'runAggregationQuery')) {
       if (reqOpts.readOptions && reqOpts.readOptions.readConsistency) {
         throw new Error(
           'Read consistency cannot be specified in a transaction.'

--- a/src/request.ts
+++ b/src/request.ts
@@ -1000,7 +1000,12 @@ class DatastoreRequest {
       reqOpts.transaction = this.id;
     }
 
-    if (isTransaction && (method === 'lookup' || method === 'runQuery' || method === 'runAggregationQuery')) {
+    if (
+      isTransaction &&
+      (method === 'lookup' ||
+        method === 'runQuery' ||
+        method === 'runAggregationQuery')
+    ) {
       if (reqOpts.readOptions && reqOpts.readOptions.readConsistency) {
         throw new Error(
           'Read consistency cannot be specified in a transaction.'

--- a/system-test/datastore.ts
+++ b/system-test/datastore.ts
@@ -1857,7 +1857,16 @@ async.each(
         });
 
         describe('aggregate query within a transaction', async () => {
-          // TODO: Add a test here to verify what data is here at this time
+          it('should run a query and return the results', async () => {
+            // Add a test here to verify what the data is at this time.
+            // This will be a valuable reference for tests in this describe block.
+            const query = datastore.createQuery('Company');
+            const [results] = await datastore.runQuery(query);
+            assert.deepStrictEqual(
+              results.map(result => result.rating),
+              [100, 100]
+            );
+          });
           it('should aggregate query within a count transaction', async () => {
             const transaction = datastore.transaction();
             await transaction.run();

--- a/system-test/datastore.ts
+++ b/system-test/datastore.ts
@@ -17,7 +17,7 @@ import {readFileSync} from 'fs';
 import * as path from 'path';
 import {after, before, describe, it} from 'mocha';
 import * as yaml from 'js-yaml';
-import {Datastore, DatastoreOptions, Index} from '../src';
+import {Datastore, DatastoreOptions, Index, Transaction} from '../src';
 import {google} from '../protos/protos';
 import {Storage} from '@google-cloud/storage';
 import {AggregateField} from '../src/aggregate';
@@ -1857,6 +1857,7 @@ async.each(
         });
 
         describe('aggregate query within a transaction', async () => {
+          // TODO: Add a test here to verify what data is here at this time
           it('should aggregate query within a count transaction', async () => {
             const transaction = datastore.transaction();
             await transaction.run();
@@ -1912,6 +1913,40 @@ async.each(
               );
             }
             assert.deepStrictEqual(result, [{'average rating': 100}]);
+            await transaction.commit();
+          });
+          it('readOnly transaction should see consistent snapshot of database', async () => {
+            async function getResults(transaction: Transaction) {
+              const query = transaction.createQuery('Company');
+              const aggregateQuery = transaction
+                .createAggregationQuery(query)
+                .count('total');
+              let result;
+              try {
+                [result] = await aggregateQuery.run();
+              } catch (e) {
+                await transaction.rollback();
+                assert.fail(
+                  'The aggregation query run should have been successful'
+                );
+              }
+              return result;
+            }
+            const key = datastore.key(['Company', 'Google']);
+            const transaction = datastore.transaction({readOnly: true});
+            await transaction.run();
+            const results = await getResults(transaction);
+            assert.deepStrictEqual(results, [{total: 2}]);
+            await datastore.save([
+              {
+                key,
+                data: {
+                  rating: 100,
+                },
+              },
+            ]);
+            const resultsAgain = await getResults(transaction);
+            assert.deepStrictEqual(resultsAgain, [{total: 2}]);
             await transaction.commit();
           });
         });


### PR DESCRIPTION
Changes:

This PR ensures that transaction reads work for run aggregation query requests. Currently, when a user uses the transaction object to run an aggregation query request then the aggregation query request does not run inside the transaction. This fix ensures that the request does run inside a transaction.

Fixes #1151 
