### PR TITLE
refactor: Replace common patterns from various transaction methods with common functions

### DIFF
--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -1040,7 +1040,7 @@ class Transaction extends DatastoreRequest {
    * user that are used for the beginTransaction grpc call.
    * @param {Resolver<T>} [resolver] A resolver object used to construct a
    * custom promise which is run after ensuring a beginTransaction call is made.
-   * @param {(...args: [Error | null, ...T] | [Error | null]) => void} [callback]
+   * @param {Function} [callback]
    * A callback provided by the user that expects an error in the first
    * argument and a custom data type for the rest of the arguments
    * @private

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -80,7 +80,6 @@ enum TransactionState {
   IN_PROGRESS, // IN_PROGRESS currently tracks the expired state as well
 }
 
-type errorType = Error | null;
 
 function callbackWithError<T extends any[]>(
   resolve: PromiseResolveFunction<T>
@@ -219,7 +218,7 @@ class Transaction extends DatastoreRequest {
   #wrapWithBeginTransaction<T extends any[]>(
     gaxOptions: CallOptions | undefined,
     resolver: Resolver<T>,
-    callback: (...args: [errorType, ...T] | [errorType]) => void
+    callback: (...args: [Error | null, ...T] | [Error | null]) => void
   ) {
     this.#withBeginTransaction(gaxOptions, resolver).then(
       (response: UserCallbackData<T>) => {

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -80,7 +80,23 @@ enum TransactionState {
   IN_PROGRESS, // IN_PROGRESS currently tracks the expired state as well
 }
 
-
+/**
+ * This function helps build resolvers from common callback data. Callback data
+ * provided by many functions contains error information in the first argument
+ * and an arbitrary response across all other arguments. It is common to build a
+ * UserCallbackData object from the callback data by setting the resp property
+ * in the UserCallbackData object to the array of arguments provided in the
+ * callback after the error argument. Since resolvers expect a UserCallbackData
+ * object, this tool becomes useful when building a resolver from a function
+ * that accepts a callback because it translates the callback data into a
+ * UserCallbackData object and allows the resolver's resolve function to consume it.
+ *
+ * @param {PromiseResolveFunction<T>} [resolve] The resolve function passed into a promise
+ * that produces a value of UserCallbackData<T> type.
+ * @returns {(err: Error | null | undefined, ...args: T) => void} returns a callback that
+ * accepts parameters with an error in the first argument and passes those parameters into
+ * a promise's resolve function after those parameters are translated.
+ */
 function callbackWithError<T extends any[]>(
   resolve: PromiseResolveFunction<T>
 ): (err: Error | null | undefined, ...args: T) => void {

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -93,9 +93,9 @@ enum TransactionState {
  *
  * @param {PromiseResolveFunction<T>} [resolve] The resolve function passed into a promise
  * that produces a value of UserCallbackData<T> type.
- * @returns {(err: Error | null | undefined, ...args: T) => void} returns a callback that
- * accepts parameters with an error in the first argument and passes those parameters into
- * a promise's resolve function after those parameters are translated.
+ * @returns {function} returns a callback that accepts parameters with an error
+ * in the first argument and passes those parameters into a promise's resolve
+ * function after those parameters are translated.
  */
 function callbackWithError<T extends any[]>(
   resolve: PromiseResolveFunction<T>
@@ -1040,9 +1040,9 @@ class Transaction extends DatastoreRequest {
    * user that are used for the beginTransaction grpc call.
    * @param {Resolver<T>} [resolver] A resolver object used to construct a
    * custom promise which is run after ensuring a beginTransaction call is made.
-   * @param {Function} [callback]
-   * A callback provided by the user that expects an error in the first
-   * argument and a custom data type for the rest of the arguments
+   * @param {function} [callback] A callback provided by the user that expects
+   * an error in the first argument and a custom data type for the rest of the
+   * arguments.
    * @private
    */
   #sendUserCallbackData<T extends any[]>(

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -121,10 +121,9 @@ function otherStandardCallback(resolve: PromiseResolveFunction<any[]>) {
 }
 */
 
-// TODO: Add a return type here.
 function callbackWithError<T extends any[]>(
   resolve: PromiseResolveFunction<T>
-) {
+): (err: Error | null | undefined, ...args: T) => void {
   return (err: Error | null | undefined, ...args: T) => {
     resolve({err: err ? err : null, resp: args});
   };

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -81,7 +81,6 @@ enum TransactionState {
 }
 
 type errorType = Error | null;
-type UserCallbackArguments<T extends any[]> = [errorType, ...T] | [errorType];
 
 function callbackWithError<T extends any[]>(
   resolve: PromiseResolveFunction<T>
@@ -220,7 +219,7 @@ class Transaction extends DatastoreRequest {
   #wrapWithBeginTransaction<T extends any[]>(
     gaxOptions: CallOptions | undefined,
     resolver: Resolver<T>,
-    callback: (...args: UserCallbackArguments<T>) => void
+    callback: (...args: [errorType, ...T] | [errorType]) => void
   ) {
     this.#withBeginTransaction(gaxOptions, resolver).then(
       (response: UserCallbackData<T>) => {

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -224,8 +224,9 @@ class Transaction extends DatastoreRequest {
         : () => {};
     const gaxOptions =
       typeof gaxOptionsOrCallback === 'object' ? gaxOptionsOrCallback : {};
-    type commitResponseType = [google.datastore.v1.ICommitResponse | undefined];
-    const resolver: Resolver<commitResponseType> = resolve => {
+    const resolver: Resolver<
+      [google.datastore.v1.ICommitResponse | undefined]
+    > = resolve => {
       this.#runCommit(gaxOptions, callbackWithError(resolve));
     };
     this.#sendUserCallbackData(gaxOptions, resolver, callback);

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -431,7 +431,6 @@ class Transaction extends DatastoreRequest {
         : {};
     const callback =
       typeof optionsOrCallback === 'function' ? optionsOrCallback : cb!;
-    // TODO: First pull out all the data inside super.get(
     const resolver: Resolver<GetResponse> = resolve => {
       super.get(keys, options, callbackWithError(resolve));
     };

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -121,6 +121,15 @@ function otherStandardCallback(resolve: PromiseResolveFunction<any[]>) {
 }
 */
 
+// TODO: Add a return type here.
+function callbackWithError<T extends any[]>(
+  resolve: PromiseResolveFunction<T>
+) {
+  return (err: Error | null | undefined, ...args: T) => {
+    resolve({err: err ? err : null, resp: args});
+  };
+}
+
 /**
  * A transaction is a set of Datastore operations on one or more entities. Each
  * transaction is guaranteed to be atomic, which means that transactions are
@@ -242,16 +251,7 @@ class Transaction extends DatastoreRequest {
       typeof gaxOptionsOrCallback === 'object' ? gaxOptionsOrCallback : {};
     type commitResponseType = [google.datastore.v1.ICommitResponse | undefined];
     const resolver: Resolver<commitResponseType> = resolve => {
-      this.#runCommit(
-        gaxOptions,
-        (err?: Error | null, resp?: google.datastore.v1.ICommitResponse) => {
-          const resolveValue: UserCallbackData<commitResponseType> = {
-            err: err ? err : null,
-            resp: [resp],
-          };
-          resolve(resolveValue);
-        }
-      );
+      this.#runCommit(gaxOptions, callbackWithError(resolve));
     };
     this.#wrapWithBeginTransaction(gaxOptions, resolver, callback);
   }
@@ -473,13 +473,7 @@ class Transaction extends DatastoreRequest {
       typeof optionsOrCallback === 'function' ? optionsOrCallback : cb!;
     // TODO: First pull out all the data inside super.get(
     const resolver: Resolver<GetResponse> = resolve => {
-      super.get(keys, options, (err?: Error | null, entity?: Entities) => {
-        const resolveValue: UserCallbackData<GetResponse> = {
-          err: err ? err : null,
-          resp: [entity],
-        };
-        resolve(resolveValue);
-      });
+      super.get(keys, options, callbackWithError(resolve));
     };
     this.#wrapWithBeginTransaction(options.gaxOptions, resolver, callback);
   }
@@ -889,13 +883,7 @@ class Transaction extends DatastoreRequest {
     const callback =
       typeof optionsOrCallback === 'function' ? optionsOrCallback : cb!;
     const resolver: Resolver<any> = resolve => {
-      super.runAggregationQuery(
-        query,
-        options,
-        (err?: Error | null, resp?: any) => {
-          resolve({err: err ? err : null, resp: [resp]});
-        }
-      );
+      super.runAggregationQuery(query, options, callbackWithError(resolve));
     };
     this.#wrapWithBeginTransaction(options.gaxOptions, resolver, callback);
   }
@@ -931,13 +919,7 @@ class Transaction extends DatastoreRequest {
     const callback =
       typeof optionsOrCallback === 'function' ? optionsOrCallback : cb!;
     const resolver: Resolver<RunQueryResponseOptional> = resolve => {
-      super.runQuery(
-        query,
-        options,
-        (err: Error | null, entities?: Entity[], info?: RunQueryInfo) => {
-          resolve({err, resp: [entities, info]});
-        }
-      );
+      super.runQuery(query, options, callbackWithError(resolve));
     };
     this.#wrapWithBeginTransaction(options.gaxOptions, resolver, callback);
   }

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -871,7 +871,6 @@ class Transaction extends DatastoreRequest {
     optionsOrCallback?: RunQueryOptions | RunQueryCallback,
     cb?: RunQueryCallback
   ): void | Promise<RunQueryResponse> {
-    // TODO: Set a breakpoint here and introspect arguments.
     const options =
       typeof optionsOrCallback === 'object' && optionsOrCallback
         ? optionsOrCallback

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -240,15 +240,12 @@ class Transaction extends DatastoreRequest {
         : () => {};
     const gaxOptions =
       typeof gaxOptionsOrCallback === 'object' ? gaxOptionsOrCallback : {};
-    const resolver: Resolver<
-      (google.datastore.v1.ICommitResponse | undefined)[]
-    > = resolve => {
+    type commitResponseType = [google.datastore.v1.ICommitResponse | undefined];
+    const resolver: Resolver<commitResponseType> = resolve => {
       this.#runCommit(
         gaxOptions,
         (err?: Error | null, resp?: google.datastore.v1.ICommitResponse) => {
-          const resolveValue: UserCallbackData<
-            (google.datastore.v1.ICommitResponse | undefined)[]
-          > = {
+          const resolveValue: UserCallbackData<commitResponseType> = {
             err: err ? err : null,
             resp: [resp],
           };
@@ -256,16 +253,7 @@ class Transaction extends DatastoreRequest {
         }
       );
     };
-    this.#withBeginTransaction(gaxOptions, resolver).then(
-      (
-        response: UserCallbackData<
-          (google.datastore.v1.ICommitResponse | undefined)[]
-        >
-      ) => {
-        const resp = response.resp ? response.resp[0] : undefined;
-        callback(response.err, resp);
-      }
-    );
+    this.#wrapWithBeginTransaction(gaxOptions, resolver, callback);
   }
 
   #wrapWithBeginTransaction<T extends any[]>(
@@ -935,7 +923,7 @@ class Transaction extends DatastoreRequest {
     optionsOrCallback?: RunQueryOptions | RunQueryCallback,
     cb?: RunQueryCallback
   ): void | Promise<RunQueryResponse> {
-    // TODO: Set a breakpoint here and intropect arguments.
+    // TODO: Set a breakpoint here and introspect arguments.
     const options =
       typeof optionsOrCallback === 'object' && optionsOrCallback
         ? optionsOrCallback
@@ -951,29 +939,7 @@ class Transaction extends DatastoreRequest {
         }
       );
     };
-    /*
-    this.#withBeginTransaction(options.gaxOptions, resolver).then(
-      (response: UserCallbackData<RunQueryResponseOptional>) => {
-        const resp: RunQueryResponseOptional | undefined = response.resp;
-        if (resp) {
-          callback(response.err, ...resp);
-        } else {
-          callback(response.err);
-        }
-      }
-    );
-     */
     this.#wrapWithBeginTransaction(options.gaxOptions, resolver, callback);
-    /*
-    this.#withBeginTransaction(options.gaxOptions, resolver).then(
-      (response: UserCallbackData<RunQueryResponseOptional>) => {
-        const error = response.err ? response.err : null;
-        const entities = response.resp ? response.resp[0] : undefined;
-        const info = response.resp ? response.resp[1] : undefined;
-        callback(error, entities, info);
-      }
-    );
-     */
   }
 
   /**

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -232,38 +232,6 @@ class Transaction extends DatastoreRequest {
   }
 
   /**
-   * This function runs custom code provided in the resolver after ensuring the
-   * transaction has been started. The custom code produces a UserCallbackData
-   * object. The UserCallbackData object is then translated into parameters and
-   * passed into the user's callback.
-   *
-   * @param {CallOptions | undefined} [gaxOptions] Gax options provided by the
-   * user that are used for the beginTransaction grpc call.
-   * @param {Resolver<T>} [resolver] A resolver object used to construct a
-   * custom promise which is run after ensuring a beginTransaction call is made.
-   * @param {(...args: [Error | null, ...T] | [Error | null]) => void} [callback]
-   * A callback provided by the user that expects an error in the first
-   * argument and a custom data type for the rest of the arguments
-   * @private
-   */
-  #sendUserCallbackData<T extends any[]>(
-    gaxOptions: CallOptions | undefined,
-    resolver: Resolver<T>,
-    callback: (...args: [Error | null, ...T] | [Error | null]) => void
-  ): void {
-    this.#withBeginTransaction(gaxOptions, resolver).then(
-      (response: UserCallbackData<T>) => {
-        const resp: T | undefined = response.resp;
-        if (resp) {
-          callback(response.err, ...resp);
-        } else {
-          callback(response.err);
-        }
-      }
-    );
-  }
-
-  /**
    * If the transaction has not begun yet then this function ensures the transaction
    * has started before running the resolver provided. The resolver is a function with one
    * argument. This argument is a function that is used to pass errors and
@@ -1059,6 +1027,38 @@ class Transaction extends DatastoreRequest {
         args: [ent],
       });
     });
+  }
+
+  /**
+   * This function runs custom code provided in the resolver after ensuring the
+   * transaction has been started. The custom code produces a UserCallbackData
+   * object. The UserCallbackData object is then translated into parameters and
+   * passed into the user's callback.
+   *
+   * @param {CallOptions | undefined} [gaxOptions] Gax options provided by the
+   * user that are used for the beginTransaction grpc call.
+   * @param {Resolver<T>} [resolver] A resolver object used to construct a
+   * custom promise which is run after ensuring a beginTransaction call is made.
+   * @param {(...args: [Error | null, ...T] | [Error | null]) => void} [callback]
+   * A callback provided by the user that expects an error in the first
+   * argument and a custom data type for the rest of the arguments
+   * @private
+   */
+  #sendUserCallbackData<T extends any[]>(
+    gaxOptions: CallOptions | undefined,
+    resolver: Resolver<T>,
+    callback: (...args: [Error | null, ...T] | [Error | null]) => void
+  ): void {
+    this.#withBeginTransaction(gaxOptions, resolver).then(
+      (response: UserCallbackData<T>) => {
+        const resp: T | undefined = response.resp;
+        if (resp) {
+          callback(response.err, ...resp);
+        } else {
+          callback(response.err);
+        }
+      }
+    );
   }
 
   /**

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -81,45 +81,7 @@ enum TransactionState {
 }
 
 type errorType = Error | null;
-type StandardCallbackArgumentsAny<T extends any[]> =
-  | [errorType, ...T]
-  | [errorType];
-/*
-type CallbacksArgumentsSupported =
-  | [errorType, ...RunQueryResponseOptional]
-  | [errorType, ...GetResponse];
-type CallbackResponsesSupported = RunQueryResponseOptional | GetResponse;
-
-// TODO: Solve problem where slice doesn't infer out error
-// TODO: List all four cases
-function standardCallback<T extends any[]>(
-  resolve: PromiseResolveFunction<CallbackResponsesSupported>
-) {
-  return (...args: CallbacksArgumentsSupported) => {
-    const someArgs = args.slice(1);
-    const err = args[0];
-    const resp: CallbackResponsesSupported = args.slice(1);
-    const resolveValue: UserCallbackData<CallbackResponsesSupported> = {
-      err,
-      resp,
-    };
-    resolve(resolveValue);
-  };
-}
-*/
-
-/*
-function otherStandardCallback(resolve: PromiseResolveFunction<any[]>) {
-  return (...args: StandardCallbackArgumentsAny<any[]>) => {
-    const resp = args.slice(1);
-    const resolveValue: UserCallbackData<any[]> = {
-      err: args[0],
-      resp,
-    };
-    resolve(resolveValue);
-  };
-}
-*/
+type UserCallbackArguments<T extends any[]> = [errorType, ...T] | [errorType];
 
 function callbackWithError<T extends any[]>(
   resolve: PromiseResolveFunction<T>
@@ -258,7 +220,7 @@ class Transaction extends DatastoreRequest {
   #wrapWithBeginTransaction<T extends any[]>(
     gaxOptions: CallOptions | undefined,
     resolver: Resolver<T>,
-    callback: (...args: StandardCallbackArgumentsAny<T>) => void
+    callback: (...args: UserCallbackArguments<T>) => void
   ) {
     this.#withBeginTransaction(gaxOptions, resolver).then(
       (response: UserCallbackData<T>) => {


### PR DESCRIPTION
**Summary**

This PR reduces code required in the transaction's get, runQuery, runAggregationQuery and commit methods by replacing similar blocks of code with common functions. Reducing the amount of code in each function reduces technical debt and makes it easier to spot decorator patterns that might simplify code even further.

**Changes**

- Added a function called **#sendUserCallbackData** to increase code reuse. This replaces the custom code contained in each call to withBeginTransaction in get, commit, runQuery and runAggregationQuery. Response data from the resolvers in each of these functions is now provided in an array format so that it can be processed by sendUserCallbackData. This lets us eliminate each of the custom callbacks in calls to withBeginTransaction.
- Added a function called **callbackWithError** which eliminates extra code used to build each resolver. This reduces the amount of code required in get, commit, runQuery and runAggregationQuery used to build a resolver because now a callback in the expected format is provided by this function.
- Finally the prior two changes enforced stronger type alignment so in UserCallbackData the error type was changed so that it couldn't be undefined to solve come compiler errors. This is expected because callbacks either receive errors or null values in the first callback argument throughout the codebase so this provides an improvement to how types line up.


