### PR TITLE
refactor: remove resolvers, remove promise in withBeginTransaction, simplify code calling withBeginTransaction

### DIFF
--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -1040,7 +1040,7 @@ class Transaction extends DatastoreRequest {
    * user that are used for the beginTransaction grpc call.
    * @param {Resolver<T>} [resolver] A resolver object used to construct a
    * custom promise which is run after ensuring a beginTransaction call is made.
-   * @param {(...args: [Error | null, ...T] | [Error | null]) => void} [callback]
+   * @param {Function} [callback]
    * A callback provided by the user that expects an error in the first
    * argument and a custom data type for the rest of the arguments
    * @private

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -48,7 +48,7 @@ import {Mutex} from 'async-mutex';
  * The data matches promises created from an argument of Resolver<T> type.
  */
 interface UserCallbackData<T> {
-  err: Error | null;
+  err?: Error | null;
   // T is the type of the data that the promise delivered to the user resolves to.
   // T also matches the type of the response data provided in the user's callback.
   resp?: T;

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -80,7 +80,6 @@ enum TransactionState {
   IN_PROGRESS, // IN_PROGRESS currently tracks the expired state as well
 }
 
-type errorType = Error | null;
 
 function callbackWithError<T extends any[]>(
   resolve: PromiseResolveFunction<T>
@@ -219,7 +218,7 @@ class Transaction extends DatastoreRequest {
   #wrapWithBeginTransaction<T extends any[]>(
     gaxOptions: CallOptions | undefined,
     resolver: Resolver<T>,
-    callback: (...args: [errorType, ...T] | [errorType]) => void
+    callback: (...args: [Error | null, ...T] | [Error | null]) => void
   ) {
     this.#withBeginTransaction(gaxOptions, resolver).then(
       (response: UserCallbackData<T>) => {

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -527,7 +527,7 @@ class Transaction extends DatastoreRequest {
       typeof optionsOrCallback === 'function' ? optionsOrCallback : cb!;
     this.#mutex.runExclusive(async () => {
       if (this.#state === TransactionState.NOT_STARTED) {
-        const runResults = await this.#runAsync(options);
+        const runResults = await this.#beginTransactionAsync(options);
         this.#processBeginResults(runResults, callback);
       } else {
         process.emitWarning(
@@ -708,7 +708,7 @@ class Transaction extends DatastoreRequest {
    *
    *
    **/
-  async #runAsync(
+  async #beginTransactionAsync(
     options: RunOptions
   ): Promise<UserCallbackData<google.datastore.v1.IBeginTransactionResponse>> {
     const reqOpts: RequestOptions = {
@@ -1044,7 +1044,9 @@ class Transaction extends DatastoreRequest {
         try {
           await this.#mutex.runExclusive(async () => {
             if (this.#state === TransactionState.NOT_STARTED) {
-              const runResults = await this.#runAsync({gaxOptions});
+              const runResults = await this.#beginTransactionAsync({
+                gaxOptions,
+              });
               this.#parseRunSuccess(runResults);
             }
           });

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -80,7 +80,23 @@ enum TransactionState {
   IN_PROGRESS, // IN_PROGRESS currently tracks the expired state as well
 }
 
-
+/**
+ * This function helps build resolvers from common callback data. Callback data
+ * provided by many functions contains error information in the first argument
+ * and an arbitrary response across all other arguments. It is common to build a
+ * UserCallbackData object from the callback data by setting the resp property
+ * in the UserCallbackData object to the array of arguments provided in the
+ * callback after the error argument. Since resolvers expect a UserCallbackData
+ * object, this tool becomes useful when building a resolver from a function
+ * that accepts a callback because it translates the callback data into a
+ * UserCallbackData object and allows the resolver's resolve function to consume it.
+ *
+ * @param {PromiseResolveFunction<T>} [resolve] The resolve function passed into a promise
+ * that produces a value of UserCallbackData<T> type.
+ * @returns {(err: Error | null | undefined, ...args: T) => void} returns a callback that
+ * accepts parameters with an error in the first argument and passes those parameters into
+ * a promise's resolve function after those parameters are translated.
+ */
 function callbackWithError<T extends any[]>(
   resolve: PromiseResolveFunction<T>
 ): (err: Error | null | undefined, ...args: T) => void {

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -93,9 +93,9 @@ enum TransactionState {
  *
  * @param {PromiseResolveFunction<T>} [resolve] The resolve function passed into a promise
  * that produces a value of UserCallbackData<T> type.
- * @returns {(err: Error | null | undefined, ...args: T) => void} returns a callback that
- * accepts parameters with an error in the first argument and passes those parameters into
- * a promise's resolve function after those parameters are translated.
+ * @returns {function} returns a callback that accepts parameters with an error
+ * in the first argument and passes those parameters into a promise's resolve
+ * function after those parameters are translated.
  */
 function callbackWithError<T extends any[]>(
   resolve: PromiseResolveFunction<T>
@@ -1040,9 +1040,9 @@ class Transaction extends DatastoreRequest {
    * user that are used for the beginTransaction grpc call.
    * @param {Resolver<T>} [resolver] A resolver object used to construct a
    * custom promise which is run after ensuring a beginTransaction call is made.
-   * @param {Function} [callback]
-   * A callback provided by the user that expects an error in the first
-   * argument and a custom data type for the rest of the arguments
+   * @param {function} [callback] A callback provided by the user that expects
+   * an error in the first argument and a custom data type for the rest of the
+   * arguments.
    * @private
    */
   #sendUserCallbackData<T extends any[]>(

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -121,10 +121,9 @@ function otherStandardCallback(resolve: PromiseResolveFunction<any[]>) {
 }
 */
 
-// TODO: Add a return type here.
 function callbackWithError<T extends any[]>(
   resolve: PromiseResolveFunction<T>
-) {
+): (err: Error | null | undefined, ...args: T) => void {
   return (err: Error | null | undefined, ...args: T) => {
     resolve({err: err ? err : null, resp: args});
   };

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -81,7 +81,6 @@ enum TransactionState {
 }
 
 type errorType = Error | null;
-type UserCallbackArguments<T extends any[]> = [errorType, ...T] | [errorType];
 
 function callbackWithError<T extends any[]>(
   resolve: PromiseResolveFunction<T>
@@ -220,7 +219,7 @@ class Transaction extends DatastoreRequest {
   #wrapWithBeginTransaction<T extends any[]>(
     gaxOptions: CallOptions | undefined,
     resolver: Resolver<T>,
-    callback: (...args: UserCallbackArguments<T>) => void
+    callback: (...args: [errorType, ...T] | [errorType]) => void
   ) {
     this.#withBeginTransaction(gaxOptions, resolver).then(
       (response: UserCallbackData<T>) => {

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -1020,9 +1020,7 @@ class Transaction extends DatastoreRequest {
       }
     });
   }
-
-  // TODO: 4 parameters is too many, reduce number of parameters.
-  // TODO: Introduce more specific types for parameters.
+  
   #sendUserCallbackData2<T extends any[]>(
     gaxOptions: CallOptions | undefined,
     fn: () => void,

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -1023,7 +1023,7 @@ class Transaction extends DatastoreRequest {
 
   // TODO: 4 parameters is too many, reduce number of parameters.
   // TODO: Introduce more specific types for parameters.
-  #sendUserCallbackData2<T extends any[], Args extends any[]>(
+  #sendUserCallbackData2<T extends any[]>(
     gaxOptions: CallOptions | undefined,
     fn: () => void,
     callback: (...args: [Error | null, ...T] | [Error | null]) => void

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -224,8 +224,9 @@ class Transaction extends DatastoreRequest {
         : () => {};
     const gaxOptions =
       typeof gaxOptionsOrCallback === 'object' ? gaxOptionsOrCallback : {};
-    type commitResponseType = [google.datastore.v1.ICommitResponse | undefined];
-    const resolver: Resolver<commitResponseType> = resolve => {
+    const resolver: Resolver<
+      [google.datastore.v1.ICommitResponse | undefined]
+    > = resolve => {
       this.#runCommit(gaxOptions, callbackWithError(resolve));
     };
     this.#sendUserCallbackData(gaxOptions, resolver, callback);

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -1049,6 +1049,7 @@ class Transaction extends DatastoreRequest {
             }
           });
         } catch (err: any) {
+          // Handle an error produced by the beginTransaction grpc call
           return callback(err);
         }
       }

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -431,7 +431,6 @@ class Transaction extends DatastoreRequest {
         : {};
     const callback =
       typeof optionsOrCallback === 'function' ? optionsOrCallback : cb!;
-    // TODO: First pull out all the data inside super.get(
     const resolver: Resolver<GetResponse> = resolve => {
       super.get(keys, options, callbackWithError(resolve));
     };

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -978,15 +978,13 @@ class Transaction extends DatastoreRequest {
   }
 
   /**
-   * This function runs custom code provided in the resolver after ensuring the
-   * transaction has been started. The custom code produces a UserCallbackData
-   * object. The UserCallbackData object is then translated into parameters and
-   * passed into the user's callback.
+   * If the transaction has not begun yet then this function ensures the transaction
+   * has started before running the function provided as a parameter.
    *
    * @param {CallOptions | undefined} [gaxOptions] Gax options provided by the
    * user that are used for the beginTransaction grpc call.
-   * @param {Resolver<T>} [resolver] A resolver object used to construct a
-   * custom promise which is run after ensuring a beginTransaction call is made.
+   * @param {function} [fn] A function which is run after ensuring a
+   * beginTransaction call is made.
    * @param {function} [callback] A callback provided by the user that expects
    * an error in the first argument and a custom data type for the rest of the
    * arguments.

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -121,6 +121,15 @@ function otherStandardCallback(resolve: PromiseResolveFunction<any[]>) {
 }
 */
 
+// TODO: Add a return type here.
+function callbackWithError<T extends any[]>(
+  resolve: PromiseResolveFunction<T>
+) {
+  return (err: Error | null | undefined, ...args: T) => {
+    resolve({err: err ? err : null, resp: args});
+  };
+}
+
 /**
  * A transaction is a set of Datastore operations on one or more entities. Each
  * transaction is guaranteed to be atomic, which means that transactions are
@@ -242,16 +251,7 @@ class Transaction extends DatastoreRequest {
       typeof gaxOptionsOrCallback === 'object' ? gaxOptionsOrCallback : {};
     type commitResponseType = [google.datastore.v1.ICommitResponse | undefined];
     const resolver: Resolver<commitResponseType> = resolve => {
-      this.#runCommit(
-        gaxOptions,
-        (err?: Error | null, resp?: google.datastore.v1.ICommitResponse) => {
-          const resolveValue: UserCallbackData<commitResponseType> = {
-            err: err ? err : null,
-            resp: [resp],
-          };
-          resolve(resolveValue);
-        }
-      );
+      this.#runCommit(gaxOptions, callbackWithError(resolve));
     };
     this.#wrapWithBeginTransaction(gaxOptions, resolver, callback);
   }
@@ -473,13 +473,7 @@ class Transaction extends DatastoreRequest {
       typeof optionsOrCallback === 'function' ? optionsOrCallback : cb!;
     // TODO: First pull out all the data inside super.get(
     const resolver: Resolver<GetResponse> = resolve => {
-      super.get(keys, options, (err?: Error | null, entity?: Entities) => {
-        const resolveValue: UserCallbackData<GetResponse> = {
-          err: err ? err : null,
-          resp: [entity],
-        };
-        resolve(resolveValue);
-      });
+      super.get(keys, options, callbackWithError(resolve));
     };
     this.#wrapWithBeginTransaction(options.gaxOptions, resolver, callback);
   }
@@ -889,13 +883,7 @@ class Transaction extends DatastoreRequest {
     const callback =
       typeof optionsOrCallback === 'function' ? optionsOrCallback : cb!;
     const resolver: Resolver<any> = resolve => {
-      super.runAggregationQuery(
-        query,
-        options,
-        (err?: Error | null, resp?: any) => {
-          resolve({err: err ? err : null, resp: [resp]});
-        }
-      );
+      super.runAggregationQuery(query, options, callbackWithError(resolve));
     };
     this.#wrapWithBeginTransaction(options.gaxOptions, resolver, callback);
   }
@@ -931,13 +919,7 @@ class Transaction extends DatastoreRequest {
     const callback =
       typeof optionsOrCallback === 'function' ? optionsOrCallback : cb!;
     const resolver: Resolver<RunQueryResponseOptional> = resolve => {
-      super.runQuery(
-        query,
-        options,
-        (err: Error | null, entities?: Entity[], info?: RunQueryInfo) => {
-          resolve({err, resp: [entities, info]});
-        }
-      );
+      super.runQuery(query, options, callbackWithError(resolve));
     };
     this.#wrapWithBeginTransaction(options.gaxOptions, resolver, callback);
   }

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -871,7 +871,6 @@ class Transaction extends DatastoreRequest {
     optionsOrCallback?: RunQueryOptions | RunQueryCallback,
     cb?: RunQueryCallback
   ): void | Promise<RunQueryResponse> {
-    // TODO: Set a breakpoint here and introspect arguments.
     const options =
       typeof optionsOrCallback === 'object' && optionsOrCallback
         ? optionsOrCallback

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -1025,7 +1025,7 @@ class Transaction extends DatastoreRequest {
   // TODO: Introduce more specific types for parameters.
   #sendUserCallbackData2<T extends any[], Args extends any[]>(
     gaxOptions: CallOptions | undefined,
-    fn: (...args: any[]) => void,
+    fn: () => void,
     callback: (...args: [Error | null, ...T] | [Error | null]) => void
   ): void {
     (async () => {

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -240,15 +240,12 @@ class Transaction extends DatastoreRequest {
         : () => {};
     const gaxOptions =
       typeof gaxOptionsOrCallback === 'object' ? gaxOptionsOrCallback : {};
-    const resolver: Resolver<
-      (google.datastore.v1.ICommitResponse | undefined)[]
-    > = resolve => {
+    type commitResponseType = [google.datastore.v1.ICommitResponse | undefined];
+    const resolver: Resolver<commitResponseType> = resolve => {
       this.#runCommit(
         gaxOptions,
         (err?: Error | null, resp?: google.datastore.v1.ICommitResponse) => {
-          const resolveValue: UserCallbackData<
-            (google.datastore.v1.ICommitResponse | undefined)[]
-          > = {
+          const resolveValue: UserCallbackData<commitResponseType> = {
             err: err ? err : null,
             resp: [resp],
           };
@@ -256,16 +253,7 @@ class Transaction extends DatastoreRequest {
         }
       );
     };
-    this.#withBeginTransaction(gaxOptions, resolver).then(
-      (
-        response: UserCallbackData<
-          (google.datastore.v1.ICommitResponse | undefined)[]
-        >
-      ) => {
-        const resp = response.resp ? response.resp[0] : undefined;
-        callback(response.err, resp);
-      }
-    );
+    this.#wrapWithBeginTransaction(gaxOptions, resolver, callback);
   }
 
   #wrapWithBeginTransaction<T extends any[]>(
@@ -935,7 +923,7 @@ class Transaction extends DatastoreRequest {
     optionsOrCallback?: RunQueryOptions | RunQueryCallback,
     cb?: RunQueryCallback
   ): void | Promise<RunQueryResponse> {
-    // TODO: Set a breakpoint here and intropect arguments.
+    // TODO: Set a breakpoint here and introspect arguments.
     const options =
       typeof optionsOrCallback === 'object' && optionsOrCallback
         ? optionsOrCallback
@@ -951,29 +939,7 @@ class Transaction extends DatastoreRequest {
         }
       );
     };
-    /*
-    this.#withBeginTransaction(options.gaxOptions, resolver).then(
-      (response: UserCallbackData<RunQueryResponseOptional>) => {
-        const resp: RunQueryResponseOptional | undefined = response.resp;
-        if (resp) {
-          callback(response.err, ...resp);
-        } else {
-          callback(response.err);
-        }
-      }
-    );
-     */
     this.#wrapWithBeginTransaction(options.gaxOptions, resolver, callback);
-    /*
-    this.#withBeginTransaction(options.gaxOptions, resolver).then(
-      (response: UserCallbackData<RunQueryResponseOptional>) => {
-        const error = response.err ? response.err : null;
-        const entities = response.resp ? response.resp[0] : undefined;
-        const info = response.resp ? response.resp[1] : undefined;
-        callback(error, entities, info);
-      }
-    );
-     */
   }
 
   /**

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -232,38 +232,6 @@ class Transaction extends DatastoreRequest {
   }
 
   /**
-   * This function runs custom code provided in the resolver after ensuring the
-   * transaction has been started. The custom code produces a UserCallbackData
-   * object. The UserCallbackData object is then translated into parameters and
-   * passed into the user's callback.
-   *
-   * @param {CallOptions | undefined} [gaxOptions] Gax options provided by the
-   * user that are used for the beginTransaction grpc call.
-   * @param {Resolver<T>} [resolver] A resolver object used to construct a
-   * custom promise which is run after ensuring a beginTransaction call is made.
-   * @param {(...args: [Error | null, ...T] | [Error | null]) => void} [callback]
-   * A callback provided by the user that expects an error in the first
-   * argument and a custom data type for the rest of the arguments
-   * @private
-   */
-  #sendUserCallbackData<T extends any[]>(
-    gaxOptions: CallOptions | undefined,
-    resolver: Resolver<T>,
-    callback: (...args: [Error | null, ...T] | [Error | null]) => void
-  ): void {
-    this.#withBeginTransaction(gaxOptions, resolver).then(
-      (response: UserCallbackData<T>) => {
-        const resp: T | undefined = response.resp;
-        if (resp) {
-          callback(response.err, ...resp);
-        } else {
-          callback(response.err);
-        }
-      }
-    );
-  }
-
-  /**
    * If the transaction has not begun yet then this function ensures the transaction
    * has started before running the resolver provided. The resolver is a function with one
    * argument. This argument is a function that is used to pass errors and
@@ -1059,6 +1027,38 @@ class Transaction extends DatastoreRequest {
         args: [ent],
       });
     });
+  }
+
+  /**
+   * This function runs custom code provided in the resolver after ensuring the
+   * transaction has been started. The custom code produces a UserCallbackData
+   * object. The UserCallbackData object is then translated into parameters and
+   * passed into the user's callback.
+   *
+   * @param {CallOptions | undefined} [gaxOptions] Gax options provided by the
+   * user that are used for the beginTransaction grpc call.
+   * @param {Resolver<T>} [resolver] A resolver object used to construct a
+   * custom promise which is run after ensuring a beginTransaction call is made.
+   * @param {(...args: [Error | null, ...T] | [Error | null]) => void} [callback]
+   * A callback provided by the user that expects an error in the first
+   * argument and a custom data type for the rest of the arguments
+   * @private
+   */
+  #sendUserCallbackData<T extends any[]>(
+    gaxOptions: CallOptions | undefined,
+    resolver: Resolver<T>,
+    callback: (...args: [Error | null, ...T] | [Error | null]) => void
+  ): void {
+    this.#withBeginTransaction(gaxOptions, resolver).then(
+      (response: UserCallbackData<T>) => {
+        const resp: T | undefined = response.resp;
+        if (resp) {
+          callback(response.err, ...resp);
+        } else {
+          callback(response.err);
+        }
+      }
+    );
   }
 
   /**

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -81,45 +81,7 @@ enum TransactionState {
 }
 
 type errorType = Error | null;
-type StandardCallbackArgumentsAny<T extends any[]> =
-  | [errorType, ...T]
-  | [errorType];
-/*
-type CallbacksArgumentsSupported =
-  | [errorType, ...RunQueryResponseOptional]
-  | [errorType, ...GetResponse];
-type CallbackResponsesSupported = RunQueryResponseOptional | GetResponse;
-
-// TODO: Solve problem where slice doesn't infer out error
-// TODO: List all four cases
-function standardCallback<T extends any[]>(
-  resolve: PromiseResolveFunction<CallbackResponsesSupported>
-) {
-  return (...args: CallbacksArgumentsSupported) => {
-    const someArgs = args.slice(1);
-    const err = args[0];
-    const resp: CallbackResponsesSupported = args.slice(1);
-    const resolveValue: UserCallbackData<CallbackResponsesSupported> = {
-      err,
-      resp,
-    };
-    resolve(resolveValue);
-  };
-}
-*/
-
-/*
-function otherStandardCallback(resolve: PromiseResolveFunction<any[]>) {
-  return (...args: StandardCallbackArgumentsAny<any[]>) => {
-    const resp = args.slice(1);
-    const resolveValue: UserCallbackData<any[]> = {
-      err: args[0],
-      resp,
-    };
-    resolve(resolveValue);
-  };
-}
-*/
+type UserCallbackArguments<T extends any[]> = [errorType, ...T] | [errorType];
 
 function callbackWithError<T extends any[]>(
   resolve: PromiseResolveFunction<T>
@@ -258,7 +220,7 @@ class Transaction extends DatastoreRequest {
   #wrapWithBeginTransaction<T extends any[]>(
     gaxOptions: CallOptions | undefined,
     resolver: Resolver<T>,
-    callback: (...args: StandardCallbackArgumentsAny<T>) => void
+    callback: (...args: UserCallbackArguments<T>) => void
   ) {
     this.#withBeginTransaction(gaxOptions, resolver).then(
       (response: UserCallbackData<T>) => {

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -741,7 +741,7 @@ class Transaction extends DatastoreRequest {
         // Always use resolve because then this function can return both the error and the response
         (err, resp) => {
           resolve({
-            err: err ? err : null,
+            err,
             resp,
           });
         }

--- a/test/transaction.ts
+++ b/test/transaction.ts
@@ -67,7 +67,6 @@ const fakePfy = Object.assign({}, pfy, {
       'save',
       'update',
       'upsert',
-      '#withBeginTransaction',
     ]);
   },
 });


### PR DESCRIPTION
**Changes:**

Modifies withBeginTransaction so that it doesn't await a promise anymore. Instead, it just calls the function that runs the code we want to run after ensuring the transaction has been started. Since the promise resolved to a UserCallbackData type, this type no longer needs to be used in this function because the promise isn't there anymore. Instead of relying on a value returned by withBeginTransaction and parsing that into callback arguments, withBeginTransaction just calls the callback directly which eliminates another layer in the call stack.

Code calling withBeginTransaction also doesn't use resolvers anymore and logic parsing the return value of withBeginTransaction isn't needed anymore either. This dramatically simplifies code necessary for all functions calling withBeginTransaction.