### PR TITLE
test: remove await from code samples

### DIFF
--- a/samples/export.js
+++ b/samples/export.js
@@ -40,7 +40,7 @@ async function main(bucket = 'YOUR_BUCKET_NAME') {
     console.log(specificExportOperation.result.outputUrl);
   }
 
-  await exportEntities();
+  exportEntities();
   // [END datastore_admin_entities_export]
 }
 

--- a/samples/import.js
+++ b/samples/import.js
@@ -45,7 +45,7 @@ async function main(file = 'YOUR_FILE_NAME') {
     await specificImportOperation.cancel();
   }
 
-  await importEntities();
+  importEntities();
   // [END datastore_admin_entities_import]
 }
 

--- a/samples/indexes.get.js
+++ b/samples/indexes.get.js
@@ -31,7 +31,7 @@ async function main(indexId = 'YOUR_INDEX_ID') {
     console.log('Properties:', metadata.properties);
   }
 
-  await getIndex();
+  getIndex();
   // [END datastore_admin_index_get]
 }
 

--- a/samples/indexes.list.js
+++ b/samples/indexes.list.js
@@ -37,7 +37,7 @@ async function main() {
       });
   }
 
-  await listIndexes();
+  listIndexes();
   // [END datastore_admin_index_list]
 }
 

--- a/samples/queryFilterOr.js
+++ b/samples/queryFilterOr.js
@@ -46,7 +46,7 @@ async function main() {
     }
   }
 
-  await queryFilterOr();
+  queryFilterOr();
   // [END datastore_query_filter_or]
 }
 

--- a/samples/queryFilterOr.js
+++ b/samples/queryFilterOr.js
@@ -50,4 +50,5 @@ async function main() {
   // [END datastore_query_filter_or]
 }
 
-exports.queryFilterOr = main;
+const args = process.argv.slice(2);
+main(...args).catch(console.error);

--- a/samples/test/queryFilterOr.test.js
+++ b/samples/test/queryFilterOr.test.js
@@ -23,8 +23,10 @@ const sinon = require('sinon');
 const {Datastore} = require('@google-cloud/datastore');
 const datastore = new Datastore();
 
-const {queryFilterOr} = require('../queryFilterOr');
+const cp = require('child_process');
 let taskKey1, taskKey2;
+
+const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
 describe('Creating a union query', () => {
   const stubConsole = function () {
@@ -67,7 +69,7 @@ describe('Creating a union query', () => {
   });
 
   it('should get a combination of items from the Datastore', async () => {
-    await queryFilterOr();
+    execSync(`node ./queryFilterOr.js`);
     assert.include(console.log.firstCall.args[0], 'Entity');
   });
 });

--- a/samples/test/queryFilterOr.test.js
+++ b/samples/test/queryFilterOr.test.js
@@ -81,7 +81,6 @@ describe('Creating a union query', () => {
   });
 
   it('should get a combination of items from the Datastore', async () => {
-    const stdout = execSync(`node ./queryFilterOr.js`);
-    assert.strictEqual(stdout, 'Entity found: Feed cats\nEntity found: Buy milk\n');
+    assert.strictEqual(execSync(`node ./queryFilterOr.js`), 'Entity found: Feed cats\nEntity found: Buy milk\n');
   });
 });


### PR DESCRIPTION
**General changes:**

A customer raised an issue where they ran the OR query sample from https://cloud.google.com/datastore/docs/samples/datastore-query-filter-or and an error was thrown on the line that starts with `await`. `await` can only be used inside an async function so the code sample should not contain `await` when it is not in an async function. This PR removes await from code samples where await is not used inside an async function.

**OR query sample changes:**

In the OR query sample tests, the assert check no longer works after removing await as console.log.firstCall now equals null. This is because console log output inside an async function is not visible outside of the function if await is not used. Therefore, we should use the execSync function like the code in the import-export.test.js sample test file to get console output from running the sample. This way the `it` block with the assert statement can read the console output and ensure it equals “Entity found: Feed cats\nEntity found: Buy milk\n”.

It is also possible that the database currently contains “Buy milk” and “Feed cats” data before the code sample is run which will affect the console output when running the OR query sample. Therefore, a script is added which runs before the OR query sample test is run. This script removes “Buy milk” and “Feed cats” data from the database so that the database starts from a consistent state and the console output is consistent in the assertion check.