### PR TITLE
test: sort results, check for sorted order

### DIFF
--- a/samples/queryFilterOr.js
+++ b/samples/queryFilterOr.js
@@ -41,6 +41,7 @@ async function main() {
       );
 
     const [entities] = await datastore.runQuery(query);
+    entities.sort();
     for (const entity of entities) {
       console.log(`Entity found: ${entity['description']}`);
     }

--- a/samples/test/queryFilterOr.test.js
+++ b/samples/test/queryFilterOr.test.js
@@ -81,6 +81,6 @@ describe('Creating a union query', () => {
   });
 
   it('should get a combination of items from the Datastore', async () => {
-    assert.strictEqual(execSync(`node ./queryFilterOr.js`), 'Entity found: Feed cats\nEntity found: Buy milk\n');
+    assert.strictEqual(execSync(`node ./queryFilterOr.js`), 'Entity found: Buy milk\nEntity found: Feed cats\n');
   });
 });


### PR DESCRIPTION
The sample test for OR queries is flakey. As the sample loops through the entities retrieved it prints out the entities and the test checks the exact string that is printed out. However, `runQuery` might fetch the entities in any order so for this test to consistently work we need to sort the entities it fetches and then compare the printed sorted entities with a string. By sorting the fetched entities it means the test will not fail if the entities are returned in a different order. The test should not expect a specific order for the entities since `runQuery` doesn't guarantee the entities to be in a specific order.