### PR TITLE
test: Restrict types inside the save function

### DIFF
--- a/src/entity.ts
+++ b/src/entity.ts
@@ -1463,7 +1463,7 @@ export interface ResponseResult {
 
 export interface EntityObject {
   data: {[k: string]: Entity};
-  excludeFromIndexes: string[];
+  excludeFromIndexes?: string[];
 }
 
 export interface Json {

--- a/src/interfaces/save.ts
+++ b/src/interfaces/save.ts
@@ -1,25 +1,57 @@
-import {entity} from '../entity';
-import {google} from '../../protos/protos';
+import {Entity, entity} from '../entity';
 
-type SaveNonArrayData = google.datastore.v1.IEntity;
+/*
+Entity data passed into save in non array form will be of type SaveNonArrayData
+and does not require name and value properties.
+ */
+type SaveNonArrayData = Entity;
 
+/*
+Entity data passed into save in an array form will be of type SaveArrayData
+so will have name and value defined because they are needed in these places:
+https://github.com/googleapis/nodejs-datastore/blob/bf3dafd8267c447a52f7764505042a60b1a9fd28/src/index.ts#L1152
+https://github.com/googleapis/nodejs-datastore/blob/bf3dafd8267c447a52f7764505042a60b1a9fd28/src/index.ts#L1134
+ */
 interface SaveArrayData {
   name: string;
-  value: google.datastore.v1.IValue;
-  excludeFromIndexes: boolean;
+  value: Entity;
+  excludeFromIndexes?: boolean;
 }
 
+/*
+When saving an entity, data in the data property of the entity is of type
+SaveDataValue. The data can either be in array form in which case it will
+match the SaveArrayData[] data type or it can be in non-array form where
+it will match the SaveNonArrayData data type.
+ */
 export type SaveDataValue = SaveArrayData[] | SaveNonArrayData;
 
+/*
+An Entity passed into save will include a Key object contained either inside
+a `key` property or inside a property indexed by the Key Symbol. If it is
+the former then it will be of type SaveEntityWithoutKeySymbol.
+ */
 interface SaveEntityWithoutKeySymbol {
   key: entity.Key;
   data: SaveDataValue;
   excludeFromIndexes?: string[];
 }
 
+/*
+An Entity passed into save will include a Key object contained either inside
+a `key` property or inside a property indexed by the Key Symbol. If it is
+the latter then it will be of type SaveEntityWithKeySymbol.
+ */
 interface SaveEntityWithKeySymbol {
   [entity.KEY_SYMBOL]: entity.Key;
   data: SaveDataValue;
 }
 
+/*
+Entities passed into the first argument of the save function are expected to be
+of type SaveEntity[] after being turned into an array. We could change the
+signature of save later to enforce this, but doing so would be a breaking change
+so we just cast this value to SaveEntity[] for now to enable strong type
+enforcement throughout this function.
+ */
 export type SaveEntity = SaveEntityWithoutKeySymbol | SaveEntityWithKeySymbol;

--- a/src/interfaces/save.ts
+++ b/src/interfaces/save.ts
@@ -1,3 +1,17 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import {Entity, entity} from '../entity';
 
 /*

--- a/src/interfaces/save.ts
+++ b/src/interfaces/save.ts
@@ -4,7 +4,9 @@ import {Entity, entity} from '../entity';
 Entity data passed into save in non array form will be of type SaveNonArrayData
 and does not require name and value properties.
  */
-type SaveNonArrayData = Entity;
+type SaveNonArrayData = {
+  [k: string]: Entity;
+};
 
 /*
 Entity data passed into save in an array form will be of type SaveArrayData

--- a/src/interfaces/save.ts
+++ b/src/interfaces/save.ts
@@ -22,10 +22,6 @@ type SaveNonArrayData = {
   [k: string]: Entity;
 };
 
-interface HasToString {
-  toString(): string;
-}
-
 /*
 Entity data passed into save in an array form will be of type SaveArrayData
 so will have name and value defined because they are needed in these places:
@@ -33,7 +29,9 @@ https://github.com/googleapis/nodejs-datastore/blob/bf3dafd8267c447a52f776450504
 https://github.com/googleapis/nodejs-datastore/blob/bf3dafd8267c447a52f7764505042a60b1a9fd28/src/index.ts#L1134
  */
 interface SaveArrayData {
-  name: HasToString;
+  name: {
+    toString(): string;
+  };
   value: Entity;
   excludeFromIndexes?: boolean;
 }

--- a/src/interfaces/save.ts
+++ b/src/interfaces/save.ts
@@ -24,9 +24,8 @@ type SaveNonArrayData = {
 
 /*
 Entity data passed into save in an array form will be of type SaveArrayData
-so will have name and value defined because they are needed in these places:
-https://github.com/googleapis/nodejs-datastore/blob/bf3dafd8267c447a52f7764505042a60b1a9fd28/src/index.ts#L1152
-https://github.com/googleapis/nodejs-datastore/blob/bf3dafd8267c447a52f7764505042a60b1a9fd28/src/index.ts#L1134
+so will have name and value defined because the source code of save requires a
+name and a value to be defined or else an error will be thrown.
  */
 interface SaveArrayData {
   name: {

--- a/src/interfaces/save.ts
+++ b/src/interfaces/save.ts
@@ -1,0 +1,24 @@
+import {entity} from '../entity';
+import {google} from '../../protos/protos';
+
+interface SaveEntityWithKeySymbol {
+  [entity.KEY_SYMBOL]: entity.Key;
+  data: SaveArrayData[] | SaveNonArrayData;
+}
+
+type SaveNonArrayData = google.datastore.v1.IEntity;
+
+interface SaveArrayData {
+  name: string;
+  value: google.datastore.v1.IValue;
+  excludeFromIndexes: boolean;
+}
+
+interface SaveEntityWithoutKeySymbol {
+  key: entity.Key;
+  data: SaveArrayData[] | SaveNonArrayData;
+}
+
+export type SaveEntity = SaveEntityWithoutKeySymbol | SaveEntityWithKeySymbol;
+
+type SaveEntities = SaveEntity | SaveEntity[];

--- a/src/interfaces/save.ts
+++ b/src/interfaces/save.ts
@@ -1,11 +1,6 @@
 import {entity} from '../entity';
 import {google} from '../../protos/protos';
 
-interface SaveEntityWithKeySymbol {
-  [entity.KEY_SYMBOL]: entity.Key;
-  data: SaveArrayData[] | SaveNonArrayData;
-}
-
 type SaveNonArrayData = google.datastore.v1.IEntity;
 
 interface SaveArrayData {
@@ -14,11 +9,17 @@ interface SaveArrayData {
   excludeFromIndexes: boolean;
 }
 
+export type SaveDataValue = SaveArrayData[] | SaveNonArrayData;
+
 interface SaveEntityWithoutKeySymbol {
   key: entity.Key;
-  data: SaveArrayData[] | SaveNonArrayData;
+  data: SaveDataValue;
+  excludeFromIndexes?: string[];
+}
+
+interface SaveEntityWithKeySymbol {
+  [entity.KEY_SYMBOL]: entity.Key;
+  data: SaveDataValue;
 }
 
 export type SaveEntity = SaveEntityWithoutKeySymbol | SaveEntityWithKeySymbol;
-
-type SaveEntities = SaveEntity | SaveEntity[];

--- a/src/interfaces/save.ts
+++ b/src/interfaces/save.ts
@@ -22,6 +22,10 @@ type SaveNonArrayData = {
   [k: string]: Entity;
 };
 
+interface HasToString {
+  toString(): string;
+}
+
 /*
 Entity data passed into save in an array form will be of type SaveArrayData
 so will have name and value defined because they are needed in these places:
@@ -29,7 +33,7 @@ https://github.com/googleapis/nodejs-datastore/blob/bf3dafd8267c447a52f776450504
 https://github.com/googleapis/nodejs-datastore/blob/bf3dafd8267c447a52f7764505042a60b1a9fd28/src/index.ts#L1134
  */
 interface SaveArrayData {
-  name: string;
+  name: HasToString;
   value: Entity;
   excludeFromIndexes?: boolean;
 }

--- a/src/request.ts
+++ b/src/request.ts
@@ -68,6 +68,7 @@ import {RunOptions} from './transaction';
 import * as protos from '../protos/protos';
 import {serializer} from 'google-gax';
 import * as gax from 'google-gax';
+import {SaveDataValue} from './interfaces/save';
 type JSONValue =
   | string
   | number
@@ -1412,8 +1413,10 @@ export interface PrepareEntityObject {
   [key: string]: google.datastore.v1.Key | undefined;
 }
 export interface PrepareEntityObjectResponse {
-  key?: google.datastore.v1.Key;
-  data?: google.datastore.v1.Entity;
+  key: entity.Key;
+  data: SaveDataValue;
+  excludeFromIndexes?: string[];
+  excludeLargeProperties?: boolean;
   method?: string;
 }
 export interface RequestCallback {

--- a/src/request.ts
+++ b/src/request.ts
@@ -1413,8 +1413,8 @@ export interface PrepareEntityObject {
   [key: string]: google.datastore.v1.Key | undefined;
 }
 export interface PrepareEntityObjectResponse {
-  key: entity.Key;
-  data: SaveDataValue;
+  key?: entity.Key;
+  data?: SaveDataValue;
   excludeFromIndexes?: string[];
   excludeLargeProperties?: boolean;
   method?: string;

--- a/test/index.ts
+++ b/test/index.ts
@@ -1586,9 +1586,11 @@ async.each(
               }
             );
           } catch (err: unknown) {
-            assert.strictEqual(
-              (err as {message: string}).message,
-              "Cannot read properties of null (reading 'toString')"
+            assert(
+              [
+                `Cannot read properties of null (reading 'toString')`, // Later Node versions
+                "Cannot read property 'toString' of null", // Node 14
+              ].includes((err as {message: string}).message)
             );
             done();
             return;


### PR DESCRIPTION
**Summary**

To solve the problem described in [go/excludefromindexes-nested-fields](https://docs.google.com/document/d/1mx__hGqgAdIcF_r-LCHSOsMVfq-lUItB9zwHJxkdmyk/edit?resourcekey=0-Lfe0GVXoBOF58eWjRk8mjA&tab=t.0#heading=h.xzptrog8pyxf) it is important to explore and document what kind of data can be passed into the save function. This PR defines interfaces and further restricts non-user facing variable types in the save source code so that the compiler will tell us when the source code is wrong. Right now, the first argument of `save` is of type `Entities` which is an alias for `any`.

Note: This PR doesn't change how the source code functions at all.

**Changes**

- Two tests are added that demonstrate that when array data is passed into save that the elements of that array must contain valid name and value properties or else an error will be thrown.
- In alignment with what is shown in the tests, a `SaveArrayData` interface is defined so that the compiler forces array data to match a type internally that won't throw an error.
- An interface `SaveNonArrayData` is defined for valid input data that is not provided in array form
- With `SaveArrayData` and `SaveNonArrayData` interfaces acting as building blocks, a hierarchy of other interfaces are defined that eventually define the `SaveEntity` interface which is now used in the save function to better restrict the data types that can be used within that function.
- In PrepareEntityObjectResponse the data types for key and data are wrong, `google.datastore.v1.Key` and `google.datastore.v1.Entity` are references to functions and `key` and `data` properties do not store functions.

**Next steps**

It would be useful to further restrict the types within the save function to make it easier to work with the complex data structures that are involved with the problem from [go/excludefromindexes-nested-fields](https://docs.google.com/document/d/1mx__hGqgAdIcF_r-LCHSOsMVfq-lUItB9zwHJxkdmyk/edit?resourcekey=0-Lfe0GVXoBOF58eWjRk8mjA&tab=t.0#heading=h.xzptrog8pyxf)