### PR TITLE
fix: Handle excludeLarge properties for arrays properly

### DIFF
--- a/src/entity.ts
+++ b/src/entity.ts
@@ -778,6 +778,7 @@ export namespace entity {
    */
   export function entityToEntityProto(entityObject: EntityObject): EntityProto {
     const properties = entityObject.data;
+    const excludeFromIndexes = entityObject.excludeFromIndexes;
 
     const entityProto: EntityProto = {
       key: null,
@@ -792,16 +793,6 @@ export namespace entity {
       ),
     };
 
-    addExcludeFromIndexes(entityObject, entityProto);
-
-    return entityProto;
-  }
-
-  export function addExcludeFromIndexes(
-    entityObject: EntityObject,
-    entityProto: EntityProto
-  ): EntityProto {
-    const excludeFromIndexes = entityObject.excludeFromIndexes;
     if (excludeFromIndexes && excludeFromIndexes.length > 0) {
       excludeFromIndexes.forEach((excludePath: string) => {
         excludePathFromEntity(entityProto, excludePath);

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -778,7 +778,6 @@ export namespace entity {
    */
   export function entityToEntityProto(entityObject: EntityObject): EntityProto {
     const properties = entityObject.data;
-    const excludeFromIndexes = entityObject.excludeFromIndexes;
 
     const entityProto: EntityProto = {
       key: null,
@@ -793,6 +792,16 @@ export namespace entity {
       ),
     };
 
+    addExcludeFromIndexes(entityObject, entityProto);
+
+    return entityProto;
+  }
+
+  export function addExcludeFromIndexes(
+    entityObject: EntityObject,
+    entityProto: EntityProto
+  ): EntityProto {
+    const excludeFromIndexes = entityObject.excludeFromIndexes;
     if (excludeFromIndexes && excludeFromIndexes.length > 0) {
       excludeFromIndexes.forEach((excludePath: string) => {
         excludePathFromEntity(entityProto, excludePath);

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -792,16 +792,15 @@ export namespace entity {
       ),
     };
 
-    addExcludeFromIndexes(entityObject, entityProto);
+    addExcludeFromIndexes(entityObject.excludeFromIndexes, entityProto);
 
     return entityProto;
   }
 
   export function addExcludeFromIndexes(
-    entityObject: EntityObject,
+    excludeFromIndexes: string[],
     entityProto: EntityProto
   ): EntityProto {
-    const excludeFromIndexes = entityObject.excludeFromIndexes;
     if (excludeFromIndexes && excludeFromIndexes.length > 0) {
       excludeFromIndexes.forEach((excludePath: string) => {
         excludePathFromEntity(entityProto, excludePath);

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,7 @@ import {google} from '../protos/protos';
 import {AggregateQuery} from './aggregate';
 
 const {grpc} = new GrpcClient();
+const addExcludeFromIndexes = entity.addExcludeFromIndexes;
 
 export type PathType = string | number | entity.Int;
 export interface BooleanObject {
@@ -1130,12 +1131,6 @@ class Datastore extends DatastoreRequest {
               acc: EntityProtoReduceAccumulator,
               data: EntityProtoReduceData
             ) => {
-              /*
-              const subEntityObject = {
-                data:
-                excludeFromIndexes: [],
-              };
-               */
               const value = entity.encodeValue(
                 data.value,
                 data.name.toString()
@@ -1161,6 +1156,7 @@ class Datastore extends DatastoreRequest {
             },
             {}
           );
+          addExcludeFromIndexes(entityObject, entityProto);
         } else {
           entityProto = entity.entityToEntityProto(entityObject);
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,6 @@ import {google} from '../protos/protos';
 import {AggregateQuery} from './aggregate';
 
 const {grpc} = new GrpcClient();
-const addExcludeFromIndexes = entity.addExcludeFromIndexes;
 
 export type PathType = string | number | entity.Int;
 export interface BooleanObject {
@@ -1131,6 +1130,12 @@ class Datastore extends DatastoreRequest {
               acc: EntityProtoReduceAccumulator,
               data: EntityProtoReduceData
             ) => {
+              /*
+              const subEntityObject = {
+                data:
+                excludeFromIndexes: [],
+              };
+               */
               const value = entity.encodeValue(
                 data.value,
                 data.name.toString()
@@ -1156,7 +1161,6 @@ class Datastore extends DatastoreRequest {
             },
             {}
           );
-          addExcludeFromIndexes(entityObject, entityProto);
         } else {
           entityProto = entity.entityToEntityProto(entityObject);
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1115,9 +1115,6 @@ class Datastore extends DatastoreRequest {
           insertIndexes[index] = true;
         }
 
-        // @TODO remove in @google-cloud/datastore@2.0.0
-        // This was replaced with a more efficient mechanism in the top-level
-        // `excludeFromIndexes` option.
         if (Array.isArray(entityObject.data)) {
           // This code populates the excludeFromIndexes list with the right values.
           if (entityObject.excludeLargeProperties) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1130,6 +1130,12 @@ class Datastore extends DatastoreRequest {
               acc: EntityProtoReduceAccumulator,
               data: EntityProtoReduceData
             ) => {
+              /*
+              const subEntityObject = {
+                data:
+                excludeFromIndexes: [],
+              };
+               */
               const value = entity.encodeValue(
                 data.value,
                 data.name.toString()

--- a/src/index.ts
+++ b/src/index.ts
@@ -1130,12 +1130,6 @@ class Datastore extends DatastoreRequest {
               acc: EntityProtoReduceAccumulator,
               data: EntityProtoReduceData
             ) => {
-              /*
-              const subEntityObject = {
-                data:
-                excludeFromIndexes: [],
-              };
-               */
               const value = entity.encodeValue(
                 data.value,
                 data.name.toString()

--- a/src/index.ts
+++ b/src/index.ts
@@ -1110,14 +1110,6 @@ class Datastore extends DatastoreRequest {
           }
         }
 
-        if (entityObject.excludeLargeProperties) {
-          entityObject.excludeFromIndexes = entity.findLargeProperties_(
-            entityObject.data,
-            '',
-            entityObject.excludeFromIndexes
-          );
-        }
-
         if (!entity.isKeyComplete(entityObject.key)) {
           insertIndexes[index] = true;
         }
@@ -1126,6 +1118,23 @@ class Datastore extends DatastoreRequest {
         // This was replaced with a more efficient mechanism in the top-level
         // `excludeFromIndexes` option.
         if (Array.isArray(entityObject.data)) {
+          // This code populates the excludeFromIndexes list with the right values.
+          entityObject.data.forEach(
+            (data: {
+              name: {
+                toString(): string;
+              };
+              value: Entity;
+              excludeFromIndexes?: boolean;
+            }) => {
+              entityObject.excludeFromIndexes = entity.findLargeProperties_(
+                entityObject.data.value,
+                data.toString(),
+                entityObject.excludeFromIndexes
+              );
+            }
+          );
+          // This code builds the right entityProto from the entityObject
           entityProto.properties = entityObject.data.reduce(
             (
               acc: EntityProtoReduceAccumulator,
@@ -1156,8 +1165,18 @@ class Datastore extends DatastoreRequest {
             },
             {}
           );
+          // This code adds excludeFromIndexes in the right places
           addExcludeFromIndexes(entityObject.excludeFromIndexes, entityProto);
         } else {
+          // This code populates the excludeFromIndexes list with the right values.
+          if (entityObject.excludeLargeProperties) {
+            entityObject.excludeFromIndexes = entity.findLargeProperties_(
+              entityObject.data,
+              '',
+              entityObject.excludeFromIndexes
+            );
+          }
+          // This code builds the right entityProto from the entityObject
           entityProto = entity.entityToEntityProto(entityObject);
         }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1119,21 +1119,23 @@ class Datastore extends DatastoreRequest {
         // `excludeFromIndexes` option.
         if (Array.isArray(entityObject.data)) {
           // This code populates the excludeFromIndexes list with the right values.
-          entityObject.data.forEach(
-            (data: {
-              name: {
-                toString(): string;
-              };
-              value: Entity;
-              excludeFromIndexes?: boolean;
-            }) => {
-              entityObject.excludeFromIndexes = entity.findLargeProperties_(
-                data.value,
-                data.name.toString(),
-                entityObject.excludeFromIndexes
-              );
-            }
-          );
+          if (entityObject.excludeLargeProperties) {
+            entityObject.data.forEach(
+              (data: {
+                name: {
+                  toString(): string;
+                };
+                value: Entity;
+                excludeFromIndexes?: boolean;
+              }) => {
+                entityObject.excludeFromIndexes = entity.findLargeProperties_(
+                  data.value,
+                  data.name.toString(),
+                  entityObject.excludeFromIndexes
+                );
+              }
+            );
+          }
           // This code builds the right entityProto from the entityObject
           entityProto.properties = entityObject.data.reduce(
             (

--- a/src/index.ts
+++ b/src/index.ts
@@ -1156,7 +1156,7 @@ class Datastore extends DatastoreRequest {
             },
             {}
           );
-          addExcludeFromIndexes(entityObject, entityProto);
+          addExcludeFromIndexes(entityObject.excludeFromIndexes, entityProto);
         } else {
           entityProto = entity.entityToEntityProto(entityObject);
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1128,8 +1128,8 @@ class Datastore extends DatastoreRequest {
               excludeFromIndexes?: boolean;
             }) => {
               entityObject.excludeFromIndexes = entity.findLargeProperties_(
-                entityObject.data.value,
-                data.toString(),
+                data.value,
+                data.name.toString(),
                 entityObject.excludeFromIndexes
               );
             }

--- a/test/gapic-mocks/commit.ts
+++ b/test/gapic-mocks/commit.ts
@@ -303,6 +303,7 @@ describe.only('Commit', () => {
     async.each(
       [
         {
+          // TODO: Add note about excludeFromIndexes that should match
           name: 'should pass the right request with a bunch of large properties excluded',
           skipped: false,
           entities: complexCaseEntities,
@@ -417,109 +418,5 @@ describe.only('Commit', () => {
         });
       }
     );
-  });
-
-  describe('should pass the right request to gapic with an object containing many long strings', () => {
-    it('should pass the right request with a bunch of large properties excluded', async () => {
-      // TODO: Add note about excludeFromIndexes that should match
-      const excludeFromIndexes = [
-        'longString',
-        'longStringArray[]',
-        'metadata.longString',
-        'metadata.obj.longStringArray[].longString',
-        'metadata.obj.longStringArray[].nestedLongStringArray[].longString',
-        'metadata.longStringArray[].longString',
-        'metadata.longStringArray[].nestedLongStringArray[].longString',
-      ];
-      const expectedMutations: google.datastore.v1.IMutation[] = [
-        {
-          upsert: {
-            properties: complexCaseProperties,
-            key,
-          },
-        },
-      ];
-      await checkSaveMutations(
-        complexCaseEntities,
-        excludeFromIndexes,
-        false,
-        expectedMutations
-      );
-      await checkSaveMutations(
-        complexCaseEntities,
-        excludeFromIndexes,
-        true,
-        expectedMutations
-      );
-    });
-    describe('should pass the right request with no indexes excluded and excludeLargeProperties set', async () => {
-      it('should pass the right properties for an object', async () => {
-        const expectedMutations: google.datastore.v1.IMutation[] = [
-          {
-            upsert: {
-              properties: complexCaseProperties,
-              key,
-            },
-          },
-        ];
-        await checkSaveMutations(
-          complexCaseEntities,
-          [],
-          true,
-          expectedMutations
-        );
-      });
-      it.skip('should pass the right properties for an array', async () => {
-        const arrayEntities = [
-          {
-            name: 'arrayEntities',
-            value: complexCaseEntities,
-          },
-        ];
-        const expectedMutations: google.datastore.v1.IMutation[] = [
-          {
-            upsert: {
-              properties: {
-                arrayEntities: {
-                  entityValue: {
-                    properties: complexCaseProperties,
-                  },
-                },
-              },
-              key,
-            },
-          },
-        ];
-        await checkSaveMutations(arrayEntities, [], true, expectedMutations);
-      });
-    });
-  });
-  describe('should pass the right request to gapic with excludeFromLargeProperties', () => {
-    it.skip('should pass the right request with a nested field', async () => {
-      const entities = [
-        {
-          name: 'field_b',
-          value: {
-            nestedField: Buffer.alloc(1501, '.').toString(),
-          },
-          excludeFromIndexes: true,
-        },
-      ];
-      const expectedMutations = [
-        {
-          upsert: {
-            properties: {
-              field_b: {
-                entityValue: {
-                  properties: {},
-                },
-              },
-            },
-            key,
-          },
-        },
-      ];
-      await checkSaveMutations(entities, [], true, expectedMutations);
-    });
   });
 });

--- a/test/gapic-mocks/commit.ts
+++ b/test/gapic-mocks/commit.ts
@@ -264,9 +264,9 @@ describe.only('Commit', () => {
           ],
         },
         {
-          // This test checks to see that when the name/value is wrapped in an array it still produces the same mutations.
+          // This test checks to see that when the name/value is wrapped in an array it parses the input differently.
           name: 'should pass the right properties for a simple name/value pair in an array',
-          skipped: true,
+          skipped: false,
           entities: [
             {
               name: 'entityName',
@@ -279,10 +279,7 @@ describe.only('Commit', () => {
             {
               upsert: {
                 properties: {
-                  name: {
-                    stringValue: 'entityName',
-                  },
-                  value: {
+                  entityName: {
                     stringValue: 'entityValue',
                   },
                 },
@@ -320,22 +317,6 @@ describe.only('Commit', () => {
           name: 'should pass the right properties for an object with excludeLargeProperties',
           skipped: false,
           entities: complexCaseEntities,
-          excludeFromIndexes: [], // Empty because excludeLargeProperties populates the list.
-          excludeLargeProperties: true,
-          expectedMutations: [
-            {
-              upsert: {
-                properties: complexCaseProperties,
-                key,
-              },
-            },
-          ],
-        },
-        {
-          // Just like 'should pass the right properties for an object with excludeLargeProperties', but for an array.
-          name: 'should pass the right properties for an array with excludeLargeProperties',
-          skipped: true,
-          entities: [complexCaseEntities],
           excludeFromIndexes: [], // Empty because excludeLargeProperties populates the list.
           excludeLargeProperties: true,
           expectedMutations: [
@@ -457,10 +438,7 @@ describe.only('Commit', () => {
             {
               upsert: {
                 properties: {
-                  name: {
-                    stringValue: 'entityName',
-                  },
-                  value: {
+                  entityName: {
                     entityValue: {
                       properties: complexCaseProperties,
                     },

--- a/test/gapic-mocks/commit.ts
+++ b/test/gapic-mocks/commit.ts
@@ -355,7 +355,7 @@ describe.only('Commit', () => {
         {
           // This test case reproduces https://github.com/googleapis/nodejs-datastore/issues/1242
           name: 'should pass the right request with a nested field',
-          skipped: true,
+          skipped: false,
           entities: [
             {
               name: 'field_b',
@@ -373,8 +373,14 @@ describe.only('Commit', () => {
                 properties: {
                   field_b: {
                     entityValue: {
-                      properties: {},
+                      properties: {
+                        nestedField: {
+                          stringValue: longString,
+                          excludeFromIndexes: true,
+                        },
+                      },
                     },
+                    excludeFromIndexes: true,
                   },
                 },
                 key,

--- a/test/gapic-mocks/commit.ts
+++ b/test/gapic-mocks/commit.ts
@@ -455,7 +455,7 @@ describe.only('Commit', () => {
         {
           // Just like the previous test, but entities are wrapped in an array
           name: 'should pass the right properties for an array with name/value pairs and excludeLargeProperties',
-          skipped: true,
+          skipped: false,
           entities: [
             {
               name: 'entityName',

--- a/test/gapic-mocks/commit.ts
+++ b/test/gapic-mocks/commit.ts
@@ -20,7 +20,7 @@ import type {CallOptions} from 'google-gax';
 import {Entities} from '../../src/entity';
 import {google} from '../../protos/protos';
 import IValue = google.datastore.v1.IValue;
-import {DatastoreOptions} from '../../src';
+
 const async = require('async');
 
 describe.only('Commit', () => {
@@ -131,172 +131,142 @@ describe.only('Commit', () => {
     },
   };
 
-  async.each(
-    [
-      {
-        namespace: `${Date.now()}`,
-      },
-      {
-        namespace: `second-db-${Date.now()}`,
-      },
-    ],
-    (clientOptions: DatastoreOptions) => {
-
+  const complexCaseProperties: {[k: string]: IValue} = {
+    longString: {
+      stringValue: longString,
+      excludeFromIndexes: true,
     },
-  );
-
-  describe('should pass the right request to gapic with an object containing many long strings', () => {
-    const complexCaseProperties: {[k: string]: IValue} = {
-      longString: {
-        stringValue: longString,
-        excludeFromIndexes: true,
+    notMetadata: {
+      booleanValue: true,
+    },
+    longStringArray: {
+      arrayValue: {
+        values: [
+          {
+            stringValue: longString,
+            excludeFromIndexes: true,
+          },
+        ],
       },
-      notMetadata: {
-        booleanValue: true,
-      },
-      longStringArray: {
-        arrayValue: {
-          values: [
-            {
-              stringValue: longString,
-              excludeFromIndexes: true,
-            },
-          ],
-        },
-      },
-      metadata: {
-        entityValue: {
-          properties: {
-            longString: {
-              stringValue: longString,
-              excludeFromIndexes: true,
-            },
-            otherProperty: {
-              stringValue: 'value',
-            },
-            obj: {
-              entityValue: {
-                properties: {
-                  longStringArray: {
-                    arrayValue: {
-                      values: [
-                        {
-                          entityValue: {
-                            properties: {
-                              longString: {
-                                stringValue: longString,
-                                excludeFromIndexes: true,
-                              },
-                              nestedLongStringArray: {
-                                arrayValue: {
-                                  values: [
-                                    {
-                                      entityValue: {
-                                        properties: {
-                                          longString: {
-                                            stringValue: longString,
-                                            excludeFromIndexes: true,
-                                          },
-                                          nestedProperty: {
-                                            booleanValue: true,
-                                          },
+    },
+    metadata: {
+      entityValue: {
+        properties: {
+          longString: {
+            stringValue: longString,
+            excludeFromIndexes: true,
+          },
+          otherProperty: {
+            stringValue: 'value',
+          },
+          obj: {
+            entityValue: {
+              properties: {
+                longStringArray: {
+                  arrayValue: {
+                    values: [
+                      {
+                        entityValue: {
+                          properties: {
+                            longString: {
+                              stringValue: longString,
+                              excludeFromIndexes: true,
+                            },
+                            nestedLongStringArray: {
+                              arrayValue: {
+                                values: [
+                                  {
+                                    entityValue: {
+                                      properties: {
+                                        longString: {
+                                          stringValue: longString,
+                                          excludeFromIndexes: true,
+                                        },
+                                        nestedProperty: {
+                                          booleanValue: true,
                                         },
                                       },
                                     },
-                                    {
-                                      entityValue: {
-                                        properties: {
-                                          longString: {
-                                            stringValue: longString,
-                                            excludeFromIndexes: true,
-                                          },
+                                  },
+                                  {
+                                    entityValue: {
+                                      properties: {
+                                        longString: {
+                                          stringValue: longString,
+                                          excludeFromIndexes: true,
                                         },
                                       },
                                     },
-                                  ],
-                                },
+                                  },
+                                ],
                               },
                             },
                           },
                         },
-                      ],
-                    },
+                      },
+                    ],
                   },
                 },
               },
             },
-            longStringArray: {
-              arrayValue: {
-                values: [
-                  {
-                    entityValue: {
-                      properties: {
-                        longString: {
-                          stringValue: longString,
-                          excludeFromIndexes: true,
-                        },
-                        nestedLongStringArray: {
-                          arrayValue: {
-                            values: [
-                              {
-                                entityValue: {
-                                  properties: {
-                                    longString: {
-                                      stringValue: longString,
-                                      excludeFromIndexes: true,
-                                    },
-                                    nestedProperty: {
-                                      booleanValue: true,
-                                    },
+          },
+          longStringArray: {
+            arrayValue: {
+              values: [
+                {
+                  entityValue: {
+                    properties: {
+                      longString: {
+                        stringValue: longString,
+                        excludeFromIndexes: true,
+                      },
+                      nestedLongStringArray: {
+                        arrayValue: {
+                          values: [
+                            {
+                              entityValue: {
+                                properties: {
+                                  longString: {
+                                    stringValue: longString,
+                                    excludeFromIndexes: true,
+                                  },
+                                  nestedProperty: {
+                                    booleanValue: true,
                                   },
                                 },
                               },
-                              {
-                                entityValue: {
-                                  properties: {
-                                    longString: {
-                                      stringValue: longString,
-                                      excludeFromIndexes: true,
-                                    },
+                            },
+                            {
+                              entityValue: {
+                                properties: {
+                                  longString: {
+                                    stringValue: longString,
+                                    excludeFromIndexes: true,
                                   },
                                 },
                               },
-                            ],
-                          },
+                            },
+                          ],
                         },
                       },
                     },
                   },
-                ],
-              },
+                },
+              ],
             },
           },
         },
       },
-    };
-    const complexCaseEntities = {
+    },
+  };
+  const complexCaseEntities = {
+    longString,
+    notMetadata: true,
+    longStringArray: [longString],
+    metadata: {
       longString,
-      notMetadata: true,
-      longStringArray: [longString],
-      metadata: {
-        longString,
-        otherProperty: 'value',
-        obj: {
-          longStringArray: [
-            {
-              longString,
-              nestedLongStringArray: [
-                {
-                  longString,
-                  nestedProperty: true,
-                },
-                {
-                  longString,
-                },
-              ],
-            },
-          ],
-        },
+      otherProperty: 'value',
+      obj: {
         longStringArray: [
           {
             longString,
@@ -312,7 +282,144 @@ describe.only('Commit', () => {
           },
         ],
       },
-    };
+      longStringArray: [
+        {
+          longString,
+          nestedLongStringArray: [
+            {
+              longString,
+              nestedProperty: true,
+            },
+            {
+              longString,
+            },
+          ],
+        },
+      ],
+    },
+  };
+
+  describe('save should pass the right properties to the gapic layer', () => {
+    async.each(
+      [
+        {
+          name: 'should pass the right request with a bunch of large properties excluded',
+          skipped: false,
+          entities: complexCaseEntities,
+          excludeFromIndexes: [
+            'longString',
+            'longStringArray[]',
+            'metadata.longString',
+            'metadata.obj.longStringArray[].longString',
+            'metadata.obj.longStringArray[].nestedLongStringArray[].longString',
+            'metadata.longStringArray[].longString',
+            'metadata.longStringArray[].nestedLongStringArray[].longString',
+          ],
+          excludeLargeProperties: false,
+          expectedMutations: [
+            {
+              upsert: {
+                properties: complexCaseProperties,
+                key,
+              },
+            },
+          ],
+        },
+        {
+          name: 'should pass the right properties for an object with excludeLargeProperties',
+          skipped: false,
+          entities: complexCaseEntities,
+          excludeFromIndexes: [], // Empty because excludeLargeProperties populates the list.
+          excludeLargeProperties: true,
+          expectedMutations: [
+            {
+              upsert: {
+                properties: complexCaseProperties,
+                key,
+              },
+            },
+          ],
+        },
+        {
+          name: 'should pass the right properties for an array with excludeLargeProperties',
+          skipped: true,
+          entities: [
+            {
+              name: 'arrayEntities',
+              value: complexCaseEntities,
+            },
+          ],
+          excludeFromIndexes: [],
+          excludeLargeProperties: true,
+          expectedMutations: [
+            {
+              upsert: {
+                properties: {
+                  arrayEntities: {
+                    entityValue: {
+                      properties: complexCaseProperties,
+                    },
+                  },
+                },
+                key,
+              },
+            },
+          ],
+        },
+        {
+          name: 'should pass the right request with a nested field',
+          skipped: true,
+          entities: [
+            {
+              name: 'field_b',
+              value: {
+                nestedField: Buffer.alloc(1501, '.').toString(),
+              },
+              excludeFromIndexes: true,
+            },
+          ],
+          excludeFromIndexes: [],
+          excludeLargeProperties: true,
+          expectedMutations: [
+            {
+              upsert: {
+                properties: {
+                  field_b: {
+                    entityValue: {
+                      properties: {},
+                    },
+                  },
+                },
+                key,
+              },
+            },
+          ],
+        },
+      ],
+      (test: {
+        name: string;
+        skipped: boolean;
+        entities: Entities;
+        excludeFromIndexes: string[];
+        excludeLargeProperties: boolean;
+        expectedMutations: google.datastore.v1.IMutation[];
+      }) => {
+        it(test.name, async function () {
+          if (test.skipped) {
+            this.skip();
+          }
+          await checkSaveMutations(
+            test.entities,
+            test.excludeFromIndexes,
+            test.excludeLargeProperties,
+            test.expectedMutations
+          );
+        });
+      }
+    );
+  });
+
+  describe('should pass the right request to gapic with an object containing many long strings', () => {
     it('should pass the right request with a bunch of large properties excluded', async () => {
       // TODO: Add note about excludeFromIndexes that should match
       const excludeFromIndexes = [

--- a/test/gapic-mocks/commit.ts
+++ b/test/gapic-mocks/commit.ts
@@ -144,7 +144,8 @@ describe('Commit', () => {
         'metadata.longString',
         'metadata.obj.longStringArray[].longString',
         'metadata.obj.longStringArray[].nestedLongStringArray[].longString',
-        'metadata.longStringArray[].*',
+        'metadata.longStringArray[].longString',
+        'metadata.longStringArray[].nestedLongStringArray[].longString',
       ];
       const expectedMutations: google.datastore.v1.IMutation[] = [
         {
@@ -250,7 +251,6 @@ describe('Commit', () => {
                                             },
                                             nestedProperty: {
                                               booleanValue: true,
-                                              excludeFromIndexes: true,
                                             },
                                           },
                                         },

--- a/test/gapic-mocks/commit.ts
+++ b/test/gapic-mocks/commit.ts
@@ -65,6 +65,7 @@ describe.only('Commit', () => {
     },
   };
 
+  // complexCaseProperties are expected mutations passed to Gapic.
   const complexCaseProperties: {[k: string]: IValue} = {
     longString: {
       stringValue: longString,
@@ -193,6 +194,7 @@ describe.only('Commit', () => {
       },
     },
   };
+  // complexCaseEntities are passed into save for the complex case.
   const complexCaseEntities = {
     longString,
     notMetadata: true,
@@ -261,6 +263,7 @@ describe.only('Commit', () => {
           ],
         },
         {
+          // Just like the previous test, but no excludeFromIndexes and excludeLargeProperties is true
           name: 'should pass the right properties for an object with excludeLargeProperties',
           skipped: false,
           entities: complexCaseEntities,
@@ -276,6 +279,7 @@ describe.only('Commit', () => {
           ],
         },
         {
+          // Just like the previous test, but entities are wrapped in an array
           name: 'should pass the right properties for an array with excludeLargeProperties',
           skipped: true,
           entities: [
@@ -302,6 +306,7 @@ describe.only('Commit', () => {
           ],
         },
         {
+          // This test case reproduces https://github.com/googleapis/nodejs-datastore/issues/1242
           name: 'should pass the right request with a nested field',
           skipped: true,
           entities: [

--- a/test/gapic-mocks/commit.ts
+++ b/test/gapic-mocks/commit.ts
@@ -1,0 +1,113 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from 'assert';
+import {describe} from 'mocha';
+import * as protos from '../../protos/protos';
+import {getInitializedDatastoreClient} from './get-initialized-datastore-client';
+import type {CallOptions} from 'google-gax';
+import {Entities} from '../../src/entity';
+import {google} from '../../protos/protos';
+
+describe('Commit', () => {
+  const clientName = 'DatastoreClient';
+  const datastore = getInitializedDatastoreClient();
+
+  // This function is used for doing assertion checks.
+  // The idea is to check that the right request gets passed to the commit function in the Gapic layer.
+  function setCommitComparison(
+    compareFn: (request: protos.google.datastore.v1.ICommitRequest) => void
+  ) {
+    const dataClient = datastore.clients_.get(clientName);
+    if (dataClient) {
+      dataClient.commit = (
+        request: protos.google.datastore.v1.ICommitRequest,
+        options: CallOptions,
+        callback: (
+          err?: unknown,
+          res?: protos.google.datastore.v1.ICommitResponse
+        ) => void
+      ) => {
+        try {
+          compareFn(request);
+        } catch (e) {
+          callback(e);
+        }
+        callback(null, {
+          mutationResults: [],
+        });
+      };
+    }
+  }
+  function expectCommitRequest(
+    expectedMutations: google.datastore.v1.IMutation[]
+  ) {
+    setCommitComparison(
+      (request: protos.google.datastore.v1.ICommitRequest) => {
+        assert.deepStrictEqual(request.mutations, expectedMutations);
+      }
+    );
+  }
+
+  describe.only('should pass the right request to gapic with excludeFromLargeProperties', () => {
+    async function runTest(
+      entities: Entities,
+      expectedMutations: google.datastore.v1.IMutation[]
+    ) {
+      expectCommitRequest(expectedMutations);
+      const postKey = datastore.key(['Post', 'post2']);
+      await datastore.save({
+        key: postKey,
+        data: entities,
+        excludeLargeProperties: true,
+      });
+    }
+    it.skip('should pass the right request to gapic with excludeFromLargeProperties', async () => {
+      const entities = [
+        {
+          name: 'field_b',
+          value: {
+            nestedField: Buffer.alloc(1501, '.').toString(),
+          },
+          excludeFromIndexes: true,
+        },
+      ];
+      const expectedMutations = [
+        {
+          upsert: {
+            properties: {
+              field_b: {
+                entityValue: {
+                  properties: {},
+                },
+              },
+            },
+            key: {
+              path: [
+                {
+                  kind: 'Post',
+                  name: 'post2',
+                },
+              ],
+              partitionId: {
+                namespaceId: 'namespace',
+              },
+            },
+          },
+        },
+      ];
+      await runTest(entities, expectedMutations);
+    });
+  });
+});

--- a/test/gapic-mocks/commit.ts
+++ b/test/gapic-mocks/commit.ts
@@ -394,7 +394,7 @@ describe.only('Commit', () => {
           skipped: true,
           entities: [
             {
-              name: 'arrayEntities',
+              name: 'entityName',
               value: complexCaseEntities,
             },
           ],
@@ -405,7 +405,7 @@ describe.only('Commit', () => {
               upsert: {
                 properties: {
                   name: {
-                    stringValue: 'arrayEntities',
+                    stringValue: 'entityName',
                   },
                   value: {
                     entityValue: {

--- a/test/gapic-mocks/commit.ts
+++ b/test/gapic-mocks/commit.ts
@@ -23,7 +23,7 @@ import IValue = google.datastore.v1.IValue;
 
 const async = require('async');
 
-describe('Commit', () => {
+describe.only('Commit', () => {
   const longString = Buffer.alloc(1501, '.').toString();
   const clientName = 'DatastoreClient';
   const datastore = getInitializedDatastoreClient();
@@ -327,6 +327,42 @@ describe('Commit', () => {
                   field_b: {
                     entityValue: {
                       properties: {},
+                    },
+                  },
+                },
+                key,
+              },
+            },
+          ],
+        },
+        {
+          // "should pass the right request with a bunch of large properties excluded" test with entities wrapped in name/value
+          name: 'should pass the right request with a name/value pair, but a bunch of large properties excluded',
+          skipped: false,
+          entities: {
+            name: 'entityName',
+            value: complexCaseEntities,
+          },
+          excludeFromIndexes: [
+            'value.longString',
+            'value.longStringArray[]',
+            'value.metadata.longString',
+            'value.metadata.obj.longStringArray[].longString',
+            'value.metadata.obj.longStringArray[].nestedLongStringArray[].longString',
+            'value.metadata.longStringArray[].longString',
+            'value.metadata.longStringArray[].nestedLongStringArray[].longString',
+          ],
+          excludeLargeProperties: false,
+          expectedMutations: [
+            {
+              upsert: {
+                properties: {
+                  name: {
+                    stringValue: 'entityName',
+                  },
+                  value: {
+                    entityValue: {
+                      properties: complexCaseProperties,
                     },
                   },
                 },

--- a/test/gapic-mocks/commit.ts
+++ b/test/gapic-mocks/commit.ts
@@ -288,7 +288,7 @@ describe('Commit', () => {
       await runTest(entities, excludeFromIndexes, false, expectedMutations);
       await runTest(entities, excludeFromIndexes, true, expectedMutations);
     });
-    describe('should pass the right request with no indexes excluded and excludeLargeProperties set', async () => {
+    describe.only('should pass the right request with no indexes excluded and excludeLargeProperties set', async () => {
       const properties: {[k: string]: IValue} = {
         longString: {
           stringValue: longString,
@@ -428,7 +428,7 @@ describe('Commit', () => {
         ];
         await runTest(entities, [], true, expectedMutations);
       });
-      it.skip('should pass the right properties for an array', async () => {
+      it('should pass the right properties for an array', async () => {
         const arrayEntities = [
           {
             name: 'arrayEntities',

--- a/test/gapic-mocks/commit.ts
+++ b/test/gapic-mocks/commit.ts
@@ -279,33 +279,6 @@ describe.only('Commit', () => {
           ],
         },
         {
-          // Just like the previous test, but entities are wrapped in an array
-          name: 'should pass the right properties for an array with excludeLargeProperties',
-          skipped: true,
-          entities: [
-            {
-              name: 'arrayEntities',
-              value: complexCaseEntities,
-            },
-          ],
-          excludeFromIndexes: [],
-          excludeLargeProperties: true,
-          expectedMutations: [
-            {
-              upsert: {
-                properties: {
-                  arrayEntities: {
-                    entityValue: {
-                      properties: complexCaseProperties,
-                    },
-                  },
-                },
-                key,
-              },
-            },
-          ],
-        },
-        {
           // This test case reproduces https://github.com/googleapis/nodejs-datastore/issues/1242
           name: 'should pass the right request with a nested field',
           skipped: true,
@@ -387,6 +360,36 @@ describe.only('Commit', () => {
                 properties: {
                   name: {
                     stringValue: 'entityName',
+                  },
+                  value: {
+                    entityValue: {
+                      properties: complexCaseProperties,
+                    },
+                  },
+                },
+                key,
+              },
+            },
+          ],
+        },
+        {
+          // Just like the previous test, but entities are wrapped in an array
+          name: 'should pass the right properties for an array with excludeLargeProperties',
+          skipped: true,
+          entities: [
+            {
+              name: 'arrayEntities',
+              value: complexCaseEntities,
+            },
+          ],
+          excludeFromIndexes: [],
+          excludeLargeProperties: true,
+          expectedMutations: [
+            {
+              upsert: {
+                properties: {
+                  name: {
+                    stringValue: 'arrayEntities',
                   },
                   value: {
                     entityValue: {

--- a/test/gapic-mocks/commit.ts
+++ b/test/gapic-mocks/commit.ts
@@ -288,7 +288,7 @@ describe('Commit', () => {
       await runTest(entities, excludeFromIndexes, false, expectedMutations);
       await runTest(entities, excludeFromIndexes, true, expectedMutations);
     });
-    describe.only('should pass the right request with no indexes excluded and excludeLargeProperties set', async () => {
+    describe('should pass the right request with no indexes excluded and excludeLargeProperties set', async () => {
       const properties: {[k: string]: IValue} = {
         longString: {
           stringValue: longString,
@@ -428,7 +428,7 @@ describe('Commit', () => {
         ];
         await runTest(entities, [], true, expectedMutations);
       });
-      it('should pass the right properties for an array', async () => {
+      it.skip('should pass the right properties for an array', async () => {
         const arrayEntities = [
           {
             name: 'arrayEntities',

--- a/test/gapic-mocks/commit.ts
+++ b/test/gapic-mocks/commit.ts
@@ -239,6 +239,59 @@ describe.only('Commit', () => {
     async.each(
       [
         {
+          name: 'should pass the right properties for a simple name/value pair',
+          skipped: false,
+          entities: {
+            name: 'entityName',
+            value: 'entityValue',
+          },
+          excludeFromIndexes: [], // Empty because excludeLargeProperties populates the list.
+          excludeLargeProperties: true,
+          expectedMutations: [
+            {
+              upsert: {
+                properties: {
+                  name: {
+                    stringValue: 'entityName',
+                  },
+                  value: {
+                    stringValue: 'entityValue',
+                  },
+                },
+                key,
+              },
+            },
+          ],
+        },
+        {
+          // This test checks to see that when the name/value is wrapped in an array it still produces the same mutations.
+          name: 'should pass the right properties for a simple name/value pair in an array',
+          skipped: true,
+          entities: [
+            {
+              name: 'entityName',
+              value: 'entityValue',
+            },
+          ],
+          excludeFromIndexes: [], // Empty because excludeLargeProperties populates the list.
+          excludeLargeProperties: true,
+          expectedMutations: [
+            {
+              upsert: {
+                properties: {
+                  name: {
+                    stringValue: 'entityName',
+                  },
+                  value: {
+                    stringValue: 'entityValue',
+                  },
+                },
+                key,
+              },
+            },
+          ],
+        },
+        {
           // This test is from a modified version of https://github.com/googleapis/nodejs-datastore/blob/bf3dafd8267c447a52f7764505042a60b1a9fd28/test/index.ts#L1773
           name: 'should pass the right request with a bunch of large properties excluded',
           skipped: false,

--- a/test/gapic-mocks/commit.ts
+++ b/test/gapic-mocks/commit.ts
@@ -23,7 +23,7 @@ import IValue = google.datastore.v1.IValue;
 
 const async = require('async');
 
-describe.only('Commit', () => {
+describe('Commit', () => {
   const longString = Buffer.alloc(1501, '.').toString();
   const clientName = 'DatastoreClient';
   const datastore = getInitializedDatastoreClient();

--- a/test/gapic-mocks/commit.ts
+++ b/test/gapic-mocks/commit.ts
@@ -337,7 +337,7 @@ describe.only('Commit', () => {
         },
         {
           // "should pass the right request with a bunch of large properties excluded" test with entities wrapped in name/value
-          name: 'should pass the right request with a name/value pair, but a bunch of large properties excluded',
+          name: 'should pass the right request with a name/value pair and a bunch of large properties excluded',
           skipped: false,
           entities: {
             name: 'entityName',
@@ -353,6 +353,34 @@ describe.only('Commit', () => {
             'value.metadata.longStringArray[].nestedLongStringArray[].longString',
           ],
           excludeLargeProperties: false,
+          expectedMutations: [
+            {
+              upsert: {
+                properties: {
+                  name: {
+                    stringValue: 'entityName',
+                  },
+                  value: {
+                    entityValue: {
+                      properties: complexCaseProperties,
+                    },
+                  },
+                },
+                key,
+              },
+            },
+          ],
+        },
+        {
+          // "should pass the right properties for an object with excludeLargeProperties" test with entities wrapped in name/value
+          name: 'should pass the right request with a name/value pair and excludeLargeProperties set to true',
+          skipped: false,
+          entities: {
+            name: 'entityName',
+            value: complexCaseEntities,
+          },
+          excludeFromIndexes: [],
+          excludeLargeProperties: true,
           expectedMutations: [
             {
               upsert: {

--- a/test/gapic-mocks/commit.ts
+++ b/test/gapic-mocks/commit.ts
@@ -229,6 +229,52 @@ describe('Commit', () => {
                         },
                       },
                     },
+                    longStringArray: {
+                      arrayValue: {
+                        values: [
+                          {
+                            entityValue: {
+                              properties: {
+                                longString: {
+                                  stringValue: longString,
+                                  excludeFromIndexes: true,
+                                },
+                                nestedLongStringArray: {
+                                  arrayValue: {
+                                    values: [
+                                      {
+                                        entityValue: {
+                                          properties: {
+                                            longString: {
+                                              stringValue: longString,
+                                              excludeFromIndexes: true,
+                                            },
+                                            nestedProperty: {
+                                              booleanValue: true,
+                                              excludeFromIndexes: true,
+                                            },
+                                          },
+                                        },
+                                      },
+                                      {
+                                        entityValue: {
+                                          properties: {
+                                            longString: {
+                                              stringValue: longString,
+                                              excludeFromIndexes: true,
+                                            },
+                                          },
+                                        },
+                                      },
+                                    ],
+                                  },
+                                },
+                              },
+                            },
+                          },
+                        ],
+                      },
+                    },
                   },
                 },
               },

--- a/test/gapic-mocks/commit.ts
+++ b/test/gapic-mocks/commit.ts
@@ -136,14 +136,14 @@ describe('Commit', () => {
         ],
       },
     };
-    it('should pass the right request with a bunch of large properties excluded', async () => {
+    it.only('should pass the right request with a bunch of large properties excluded', async () => {
+      // TODO: Add note about excludeFromIndexes that should match
       const excludeFromIndexes = [
         'longString',
-        'notMetadata',
         'longStringArray[]',
         'metadata.longString',
-        'metadata.otherProperty',
-        'metadata.obj.*',
+        'metadata.obj.longStringArray[].longString',
+        'metadata.obj.longStringArray[].nestedLongStringArray[].longString',
         'metadata.longStringArray[].*',
       ];
       const expectedMutations: google.datastore.v1.IMutation[] = [
@@ -156,7 +156,6 @@ describe('Commit', () => {
               },
               notMetadata: {
                 booleanValue: true,
-                excludeFromIndexes: true,
               },
               longStringArray: {
                 arrayValue: {
@@ -177,7 +176,6 @@ describe('Commit', () => {
                     },
                     otherProperty: {
                       stringValue: 'value',
-                      excludeFromIndexes: true,
                     },
                     obj: {
                       entityValue: {
@@ -204,7 +202,6 @@ describe('Commit', () => {
                                                   },
                                                   nestedProperty: {
                                                     booleanValue: true,
-                                                    excludeFromIndexes: true,
                                                   },
                                                 },
                                               },

--- a/test/gapic-mocks/commit.ts
+++ b/test/gapic-mocks/commit.ts
@@ -263,10 +263,26 @@ describe.only('Commit', () => {
           ],
         },
         {
-          // Just like the previous test, but no excludeFromIndexes and excludeLargeProperties is true
+          // Just like 'should pass the right request with a bunch of large properties excluded', but excludeLargeProperties is true
           name: 'should pass the right properties for an object with excludeLargeProperties',
           skipped: false,
           entities: complexCaseEntities,
+          excludeFromIndexes: [], // Empty because excludeLargeProperties populates the list.
+          excludeLargeProperties: true,
+          expectedMutations: [
+            {
+              upsert: {
+                properties: complexCaseProperties,
+                key,
+              },
+            },
+          ],
+        },
+        {
+          // Just like 'should pass the right properties for an object with excludeLargeProperties', but for an array.
+          name: 'should pass the right properties for an array with excludeLargeProperties',
+          skipped: true,
+          entities: [complexCaseEntities],
           excludeFromIndexes: [], // Empty because excludeLargeProperties populates the list.
           excludeLargeProperties: true,
           expectedMutations: [

--- a/test/gapic-mocks/commit.ts
+++ b/test/gapic-mocks/commit.ts
@@ -237,7 +237,7 @@ describe.only('Commit', () => {
     async.each(
       [
         {
-          // TODO: Add note about excludeFromIndexes that should match
+          // This test is from a modified version of https://github.com/googleapis/nodejs-datastore/blob/bf3dafd8267c447a52f7764505042a60b1a9fd28/test/index.ts#L1773
           name: 'should pass the right request with a bunch of large properties excluded',
           skipped: false,
           entities: complexCaseEntities,

--- a/test/gapic-mocks/commit.ts
+++ b/test/gapic-mocks/commit.ts
@@ -97,6 +97,134 @@ describe('Commit', () => {
         excludeLargeProperties,
       });
     }
+    const properties: {[k: string]: IValue} = {
+      longString: {
+        stringValue: longString,
+        excludeFromIndexes: true,
+      },
+      notMetadata: {
+        booleanValue: true,
+      },
+      longStringArray: {
+        arrayValue: {
+          values: [
+            {
+              stringValue: longString,
+              excludeFromIndexes: true,
+            },
+          ],
+        },
+      },
+      metadata: {
+        entityValue: {
+          properties: {
+            longString: {
+              stringValue: longString,
+              excludeFromIndexes: true,
+            },
+            otherProperty: {
+              stringValue: 'value',
+            },
+            obj: {
+              entityValue: {
+                properties: {
+                  longStringArray: {
+                    arrayValue: {
+                      values: [
+                        {
+                          entityValue: {
+                            properties: {
+                              longString: {
+                                stringValue: longString,
+                                excludeFromIndexes: true,
+                              },
+                              nestedLongStringArray: {
+                                arrayValue: {
+                                  values: [
+                                    {
+                                      entityValue: {
+                                        properties: {
+                                          longString: {
+                                            stringValue: longString,
+                                            excludeFromIndexes: true,
+                                          },
+                                          nestedProperty: {
+                                            booleanValue: true,
+                                          },
+                                        },
+                                      },
+                                    },
+                                    {
+                                      entityValue: {
+                                        properties: {
+                                          longString: {
+                                            stringValue: longString,
+                                            excludeFromIndexes: true,
+                                          },
+                                        },
+                                      },
+                                    },
+                                  ],
+                                },
+                              },
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+            longStringArray: {
+              arrayValue: {
+                values: [
+                  {
+                    entityValue: {
+                      properties: {
+                        longString: {
+                          stringValue: longString,
+                          excludeFromIndexes: true,
+                        },
+                        nestedLongStringArray: {
+                          arrayValue: {
+                            values: [
+                              {
+                                entityValue: {
+                                  properties: {
+                                    longString: {
+                                      stringValue: longString,
+                                      excludeFromIndexes: true,
+                                    },
+                                    nestedProperty: {
+                                      booleanValue: true,
+                                    },
+                                  },
+                                },
+                              },
+                              {
+                                entityValue: {
+                                  properties: {
+                                    longString: {
+                                      stringValue: longString,
+                                      excludeFromIndexes: true,
+                                    },
+                                  },
+                                },
+                              },
+                            ],
+                          },
+                        },
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    };
     const entities = {
       longString,
       notMetadata: true,
@@ -136,7 +264,7 @@ describe('Commit', () => {
         ],
       },
     };
-    it.only('should pass the right request with a bunch of large properties excluded', async () => {
+    it('should pass the right request with a bunch of large properties excluded', async () => {
       // TODO: Add note about excludeFromIndexes that should match
       const excludeFromIndexes = [
         'longString',
@@ -150,134 +278,7 @@ describe('Commit', () => {
       const expectedMutations: google.datastore.v1.IMutation[] = [
         {
           upsert: {
-            properties: {
-              longString: {
-                stringValue: longString,
-                excludeFromIndexes: true,
-              },
-              notMetadata: {
-                booleanValue: true,
-              },
-              longStringArray: {
-                arrayValue: {
-                  values: [
-                    {
-                      stringValue: longString,
-                      excludeFromIndexes: true,
-                    },
-                  ],
-                },
-              },
-              metadata: {
-                entityValue: {
-                  properties: {
-                    longString: {
-                      stringValue: longString,
-                      excludeFromIndexes: true,
-                    },
-                    otherProperty: {
-                      stringValue: 'value',
-                    },
-                    obj: {
-                      entityValue: {
-                        properties: {
-                          longStringArray: {
-                            arrayValue: {
-                              values: [
-                                {
-                                  entityValue: {
-                                    properties: {
-                                      longString: {
-                                        stringValue: longString,
-                                        excludeFromIndexes: true,
-                                      },
-                                      nestedLongStringArray: {
-                                        arrayValue: {
-                                          values: [
-                                            {
-                                              entityValue: {
-                                                properties: {
-                                                  longString: {
-                                                    stringValue: longString,
-                                                    excludeFromIndexes: true,
-                                                  },
-                                                  nestedProperty: {
-                                                    booleanValue: true,
-                                                  },
-                                                },
-                                              },
-                                            },
-                                            {
-                                              entityValue: {
-                                                properties: {
-                                                  longString: {
-                                                    stringValue: longString,
-                                                    excludeFromIndexes: true,
-                                                  },
-                                                },
-                                              },
-                                            },
-                                          ],
-                                        },
-                                      },
-                                    },
-                                  },
-                                },
-                              ],
-                            },
-                          },
-                        },
-                      },
-                    },
-                    longStringArray: {
-                      arrayValue: {
-                        values: [
-                          {
-                            entityValue: {
-                              properties: {
-                                longString: {
-                                  stringValue: longString,
-                                  excludeFromIndexes: true,
-                                },
-                                nestedLongStringArray: {
-                                  arrayValue: {
-                                    values: [
-                                      {
-                                        entityValue: {
-                                          properties: {
-                                            longString: {
-                                              stringValue: longString,
-                                              excludeFromIndexes: true,
-                                            },
-                                            nestedProperty: {
-                                              booleanValue: true,
-                                            },
-                                          },
-                                        },
-                                      },
-                                      {
-                                        entityValue: {
-                                          properties: {
-                                            longString: {
-                                              stringValue: longString,
-                                              excludeFromIndexes: true,
-                                            },
-                                          },
-                                        },
-                                      },
-                                    ],
-                                  },
-                                },
-                              },
-                            },
-                          },
-                        ],
-                      },
-                    },
-                  },
-                },
-              },
-            },
+            properties,
             key,
           },
         },
@@ -286,134 +287,6 @@ describe('Commit', () => {
       await runTest(entities, excludeFromIndexes, true, expectedMutations);
     });
     describe('should pass the right request with no indexes excluded and excludeLargeProperties set', async () => {
-      const properties: {[k: string]: IValue} = {
-        longString: {
-          stringValue: longString,
-          excludeFromIndexes: true,
-        },
-        notMetadata: {
-          booleanValue: true,
-        },
-        longStringArray: {
-          arrayValue: {
-            values: [
-              {
-                stringValue: longString,
-                excludeFromIndexes: true,
-              },
-            ],
-          },
-        },
-        metadata: {
-          entityValue: {
-            properties: {
-              longString: {
-                stringValue: longString,
-                excludeFromIndexes: true,
-              },
-              otherProperty: {
-                stringValue: 'value',
-              },
-              obj: {
-                entityValue: {
-                  properties: {
-                    longStringArray: {
-                      arrayValue: {
-                        values: [
-                          {
-                            entityValue: {
-                              properties: {
-                                longString: {
-                                  stringValue: longString,
-                                  excludeFromIndexes: true,
-                                },
-                                nestedLongStringArray: {
-                                  arrayValue: {
-                                    values: [
-                                      {
-                                        entityValue: {
-                                          properties: {
-                                            longString: {
-                                              stringValue: longString,
-                                              excludeFromIndexes: true,
-                                            },
-                                            nestedProperty: {
-                                              booleanValue: true,
-                                            },
-                                          },
-                                        },
-                                      },
-                                      {
-                                        entityValue: {
-                                          properties: {
-                                            longString: {
-                                              stringValue: longString,
-                                              excludeFromIndexes: true,
-                                            },
-                                          },
-                                        },
-                                      },
-                                    ],
-                                  },
-                                },
-                              },
-                            },
-                          },
-                        ],
-                      },
-                    },
-                  },
-                },
-              },
-              longStringArray: {
-                arrayValue: {
-                  values: [
-                    {
-                      entityValue: {
-                        properties: {
-                          longString: {
-                            stringValue: longString,
-                            excludeFromIndexes: true,
-                          },
-                          nestedLongStringArray: {
-                            arrayValue: {
-                              values: [
-                                {
-                                  entityValue: {
-                                    properties: {
-                                      longString: {
-                                        stringValue: longString,
-                                        excludeFromIndexes: true,
-                                      },
-                                      nestedProperty: {
-                                        booleanValue: true,
-                                      },
-                                    },
-                                  },
-                                },
-                                {
-                                  entityValue: {
-                                    properties: {
-                                      longString: {
-                                        stringValue: longString,
-                                        excludeFromIndexes: true,
-                                      },
-                                    },
-                                  },
-                                },
-                              ],
-                            },
-                          },
-                        },
-                      },
-                    },
-                  ],
-                },
-              },
-            },
-          },
-        },
-      };
       it('should pass the right properties for an object', async () => {
         const expectedMutations: google.datastore.v1.IMutation[] = [
           {

--- a/test/gapic-mocks/commit.ts
+++ b/test/gapic-mocks/commit.ts
@@ -390,7 +390,7 @@ describe.only('Commit', () => {
         },
         {
           // Just like the previous test, but entities are wrapped in an array
-          name: 'should pass the right properties for an array with excludeLargeProperties',
+          name: 'should pass the right properties for an array with name/value pairs and excludeLargeProperties',
           skipped: true,
           entities: [
             {

--- a/test/gapic-mocks/commit.ts
+++ b/test/gapic-mocks/commit.ts
@@ -289,6 +289,55 @@ describe('Commit', () => {
           ],
         },
         {
+          name: 'should position excludeFromIndexes in the right place when provided at the top level',
+          skipped: false,
+          entities: [
+            {
+              name: 'entityName',
+              value: 'entityValue',
+              excludeFromIndexes: true,
+            },
+          ],
+          excludeFromIndexes: [],
+          expectedMutations: [
+            {
+              upsert: {
+                properties: {
+                  entityName: {
+                    stringValue: 'entityValue',
+                    excludeFromIndexes: true,
+                  },
+                },
+                key,
+              },
+            },
+          ],
+        },
+        {
+          name: 'should pass the right properties for a simple name/value pair in an array with excludeFromIndexes list',
+          skipped: false,
+          entities: [
+            {
+              name: 'entityName',
+              value: 'entityValue',
+            },
+          ],
+          excludeFromIndexes: ['entityName'],
+          excludeLargeProperties: true,
+          expectedMutations: [
+            {
+              upsert: {
+                properties: {
+                  entityName: {
+                    stringValue: 'entityValue',
+                  },
+                },
+                key,
+              },
+            },
+          ],
+        },
+        {
           // This test is from a modified version of https://github.com/googleapis/nodejs-datastore/blob/bf3dafd8267c447a52f7764505042a60b1a9fd28/test/index.ts#L1773
           name: 'should pass the right request with a bunch of large properties excluded',
           skipped: false,

--- a/test/index.ts
+++ b/test/index.ts
@@ -88,7 +88,6 @@ const fakeEntityInit: any = {
   keyToKeyProto: entity.keyToKeyProto,
   encodeValue: entity.encodeValue,
   entityToEntityProto: entity.entityToEntityProto,
-  addExcludeFromIndexes: entity.addExcludeFromIndexes,
   findLargeProperties_: entity.findLargeProperties_,
   URLSafeKey: entity.URLSafeKey,
 };

--- a/test/index.ts
+++ b/test/index.ts
@@ -88,6 +88,7 @@ const fakeEntityInit: any = {
   keyToKeyProto: entity.keyToKeyProto,
   encodeValue: entity.encodeValue,
   entityToEntityProto: entity.entityToEntityProto,
+  addExcludeFromIndexes: entity.addExcludeFromIndexes,
   findLargeProperties_: entity.findLargeProperties_,
   URLSafeKey: entity.URLSafeKey,
 };


### PR DESCRIPTION
**Summary**

This PR contains the fix for solving [this issue](https://github.com/googleapis/nodejs-datastore/issues/1242) where `excludeLargeProperties: true` doesn't work properly for arrays. It also ensures that the fix doesn't break existing use cases.

**Background**

This PR is a successor to [this other PR](https://github.com/googleapis/nodejs-datastore/pull/1263) and contains a fix that addresses the failing test cases in the other PR.

**Changes**

- `entityToEntityProto` used to have functionality that would add `excludeFromIndexes: true` in the right places, but we move this code into a separate `addExcludeFromIndexes` function because we want to reuse it for arrays.
- In `save` the code that calls `findLargeProperties_` is moved so that it is only used as is for non array data. For the array data this `findLargeProperties_` code is used per element to populate the `excludeFromIndexes` list in the correct manner.
- For array data, now that `excludeFromIndexes` list is correctly calculated we can use the `addExcludeFromIndexes` functionality that we pulled out to apply `excludeFromIndexes: true` in the right places.

**Next Steps**

- Add an integration test containing the code mentioned in the issue.
- Add integration tests that uses the JSON array of tests from this PR.
- Make the save function more modular.
- Add some more test cases just to be sure