### PR TITLE
fix: Add excludeFromIndexes in the proper places for large properties of nested fields

### DIFF
--- a/protos/protos.json
+++ b/protos/protos.json
@@ -1,4 +1,7 @@
 {
+  "options": {
+    "syntax": "proto3"
+  },
   "nested": {
     "google": {
       "nested": {

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -1463,7 +1463,7 @@ export interface ResponseResult {
 
 export interface EntityObject {
   data: {[k: string]: Entity};
-  excludeFromIndexes: string[];
+  excludeFromIndexes?: string[];
 }
 
 export interface Json {

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -778,7 +778,6 @@ export namespace entity {
    */
   export function entityToEntityProto(entityObject: EntityObject): EntityProto {
     const properties = entityObject.data;
-    const excludeFromIndexes = entityObject.excludeFromIndexes;
 
     const entityProto: EntityProto = {
       key: null,
@@ -793,6 +792,15 @@ export namespace entity {
       ),
     };
 
+    addExcludeFromIndexes(entityObject.excludeFromIndexes, entityProto);
+
+    return entityProto;
+  }
+
+  export function addExcludeFromIndexes(
+    excludeFromIndexes: string[] | undefined,
+    entityProto: EntityProto
+  ): EntityProto {
     if (excludeFromIndexes && excludeFromIndexes.length > 0) {
       excludeFromIndexes.forEach((excludePath: string) => {
         excludePathFromEntity(entityProto, excludePath);

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,7 @@ import {AggregateQuery} from './aggregate';
 import {SaveEntity} from './interfaces/save';
 
 const {grpc} = new GrpcClient();
+const addExcludeFromIndexes = entity.addExcludeFromIndexes;
 
 export type PathType = string | number | entity.Int;
 export interface BooleanObject {
@@ -1110,22 +1111,30 @@ class Datastore extends DatastoreRequest {
           }
         }
 
-        if (entityObject.excludeLargeProperties) {
-          entityObject.excludeFromIndexes = entity.findLargeProperties_(
-            entityObject.data,
-            '',
-            entityObject.excludeFromIndexes
-          );
-        }
-
         if (!entity.isKeyComplete(entityObject.key)) {
           insertIndexes[index] = true;
         }
 
-        // @TODO remove in @google-cloud/datastore@2.0.0
-        // This was replaced with a more efficient mechanism in the top-level
-        // `excludeFromIndexes` option.
         if (Array.isArray(entityObject.data)) {
+          // This code populates the excludeFromIndexes list with the right values.
+          if (entityObject.excludeLargeProperties) {
+            entityObject.data.forEach(
+              (data: {
+                name: {
+                  toString(): string;
+                };
+                value: Entity;
+                excludeFromIndexes?: boolean;
+              }) => {
+                entityObject.excludeFromIndexes = entity.findLargeProperties_(
+                  data.value,
+                  data.name.toString(),
+                  entityObject.excludeFromIndexes
+                );
+              }
+            );
+          }
+          // This code builds the right entityProto from the entityObject
           entityProto.properties = entityObject.data.reduce(
             (
               acc: EntityProtoReduceAccumulator,
@@ -1156,7 +1165,18 @@ class Datastore extends DatastoreRequest {
             },
             {}
           );
+          // This code adds excludeFromIndexes in the right places
+          addExcludeFromIndexes(entityObject.excludeFromIndexes, entityProto);
         } else {
+          // This code populates the excludeFromIndexes list with the right values.
+          if (entityObject.excludeLargeProperties) {
+            entityObject.excludeFromIndexes = entity.findLargeProperties_(
+              entityObject.data,
+              '',
+              entityObject.excludeFromIndexes
+            );
+          }
+          // This code builds the right entityProto from the entityObject
           entityProto = entity.entityToEntityProto(entityObject);
         }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,7 @@ import {Transaction} from './transaction';
 import {promisifyAll} from '@google-cloud/promisify';
 import {google} from '../protos/protos';
 import {AggregateQuery} from './aggregate';
+import {SaveEntity} from './interfaces/save';
 
 const {grpc} = new GrpcClient();
 
@@ -1076,7 +1077,7 @@ class Datastore extends DatastoreRequest {
     gaxOptionsOrCallback?: CallOptions | SaveCallback,
     cb?: SaveCallback
   ): void | Promise<SaveResponse> {
-    entities = arrify(entities);
+    entities = arrify(entities) as SaveEntity[];
     const gaxOptions =
       typeof gaxOptionsOrCallback === 'object' ? gaxOptionsOrCallback : {};
     const callback =

--- a/src/interfaces/save.ts
+++ b/src/interfaces/save.ts
@@ -1,0 +1,74 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Entity, entity} from '../entity';
+
+/*
+Entity data passed into save in non array form will be of type SaveNonArrayData
+and does not require name and value properties.
+ */
+type SaveNonArrayData = {
+  [k: string]: Entity;
+};
+
+/*
+Entity data passed into save in an array form will be of type SaveArrayData
+so will have name and value defined because the source code of save requires a
+name and a value to be defined or else an error will be thrown.
+ */
+interface SaveArrayData {
+  name: {
+    toString(): string;
+  };
+  value: Entity;
+  excludeFromIndexes?: boolean;
+}
+
+/*
+When saving an entity, data in the data property of the entity is of type
+SaveDataValue. The data can either be in array form in which case it will
+match the SaveArrayData[] data type or it can be in non-array form where
+it will match the SaveNonArrayData data type.
+ */
+export type SaveDataValue = SaveArrayData[] | SaveNonArrayData;
+
+/*
+An Entity passed into save will include a Key object contained either inside
+a `key` property or inside a property indexed by the Key Symbol. If it is
+the former then it will be of type SaveEntityWithoutKeySymbol.
+ */
+interface SaveEntityWithoutKeySymbol {
+  key: entity.Key;
+  data: SaveDataValue;
+  excludeFromIndexes?: string[];
+}
+
+/*
+An Entity passed into save will include a Key object contained either inside
+a `key` property or inside a property indexed by the Key Symbol. If it is
+the latter then it will be of type SaveEntityWithKeySymbol.
+ */
+interface SaveEntityWithKeySymbol {
+  [entity.KEY_SYMBOL]: entity.Key;
+  data: SaveDataValue;
+}
+
+/*
+Entities passed into the first argument of the save function are expected to be
+of type SaveEntity[] after being turned into an array. We could change the
+signature of save later to enforce this, but doing so would be a breaking change
+so we just cast this value to SaveEntity[] for now to enable strong type
+enforcement throughout this function.
+ */
+export type SaveEntity = SaveEntityWithoutKeySymbol | SaveEntityWithKeySymbol;

--- a/src/request.ts
+++ b/src/request.ts
@@ -68,6 +68,7 @@ import {RunOptions} from './transaction';
 import * as protos from '../protos/protos';
 import {serializer} from 'google-gax';
 import * as gax from 'google-gax';
+import {SaveDataValue} from './interfaces/save';
 type JSONValue =
   | string
   | number
@@ -1412,8 +1413,10 @@ export interface PrepareEntityObject {
   [key: string]: google.datastore.v1.Key | undefined;
 }
 export interface PrepareEntityObjectResponse {
-  key?: google.datastore.v1.Key;
-  data?: google.datastore.v1.Entity;
+  key?: entity.Key;
+  data?: SaveDataValue;
+  excludeFromIndexes?: string[];
+  excludeLargeProperties?: boolean;
   method?: string;
 }
 export interface RequestCallback {

--- a/test/gapic-mocks/commit.ts
+++ b/test/gapic-mocks/commit.ts
@@ -28,31 +28,6 @@ describe('Commit', () => {
   const clientName = 'DatastoreClient';
   const datastore = getInitializedDatastoreClient();
 
-  function setCommitComparison(
-    compareFn: (request: protos.google.datastore.v1.ICommitRequest) => void
-  ) {
-    const dataClient = datastore.clients_.get(clientName);
-    if (dataClient) {
-      dataClient.commit = (
-        request: protos.google.datastore.v1.ICommitRequest,
-        options: CallOptions,
-        callback: (
-          err?: unknown,
-          res?: protos.google.datastore.v1.ICommitResponse
-        ) => void
-      ) => {
-        try {
-          compareFn(request);
-        } catch (e) {
-          callback(e);
-        }
-        callback(null, {
-          mutationResults: [],
-        });
-      };
-    }
-  }
-
   const key = {
     path: [
       {
@@ -315,7 +290,7 @@ describe('Commit', () => {
         },
         {
           name: 'should pass the right properties for a simple name/value pair in an array with excludeFromIndexes list',
-          skipped: true,
+          skipped: false,
           entities: [
             {
               name: 'entityName',
@@ -380,7 +355,7 @@ describe('Commit', () => {
         {
           // This test case reproduces https://github.com/googleapis/nodejs-datastore/issues/1242
           name: 'should pass the right request with a nested field',
-          skipped: true,
+          skipped: false,
           entities: [
             {
               name: 'field_b',
@@ -480,7 +455,7 @@ describe('Commit', () => {
         {
           // Just like the previous test, but entities are wrapped in an array
           name: 'should pass the right properties for an array with name/value pairs and excludeLargeProperties',
-          skipped: true,
+          skipped: false,
           entities: [
             {
               name: 'entityName',

--- a/test/gapic-mocks/commit.ts
+++ b/test/gapic-mocks/commit.ts
@@ -1,0 +1,581 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from 'assert';
+import {describe} from 'mocha';
+import * as protos from '../../protos/protos';
+import {getInitializedDatastoreClient} from './get-initialized-datastore-client';
+import type {CallOptions} from 'google-gax';
+import {Entities} from '../../src/entity';
+import {google} from '../../protos/protos';
+import IValue = google.datastore.v1.IValue;
+
+const async = require('async');
+
+describe('Commit', () => {
+  const longString = Buffer.alloc(1501, '.').toString();
+  const clientName = 'DatastoreClient';
+  const datastore = getInitializedDatastoreClient();
+
+  function setCommitComparison(
+    compareFn: (request: protos.google.datastore.v1.ICommitRequest) => void
+  ) {
+    const dataClient = datastore.clients_.get(clientName);
+    if (dataClient) {
+      dataClient.commit = (
+        request: protos.google.datastore.v1.ICommitRequest,
+        options: CallOptions,
+        callback: (
+          err?: unknown,
+          res?: protos.google.datastore.v1.ICommitResponse
+        ) => void
+      ) => {
+        try {
+          compareFn(request);
+        } catch (e) {
+          callback(e);
+        }
+        callback(null, {
+          mutationResults: [],
+        });
+      };
+    }
+  }
+
+  const key = {
+    path: [
+      {
+        kind: 'Post',
+        name: 'post2',
+      },
+    ],
+    partitionId: {
+      namespaceId: 'namespace',
+    },
+  };
+
+  // complexCaseProperties are expected mutations passed to Gapic.
+  const complexCaseProperties: {[k: string]: IValue} = {
+    longString: {
+      stringValue: longString,
+      excludeFromIndexes: true,
+    },
+    notMetadata: {
+      booleanValue: true,
+    },
+    longStringArray: {
+      arrayValue: {
+        values: [
+          {
+            stringValue: longString,
+            excludeFromIndexes: true,
+          },
+        ],
+      },
+    },
+    metadata: {
+      entityValue: {
+        properties: {
+          longString: {
+            stringValue: longString,
+            excludeFromIndexes: true,
+          },
+          otherProperty: {
+            stringValue: 'value',
+          },
+          obj: {
+            entityValue: {
+              properties: {
+                longStringArray: {
+                  arrayValue: {
+                    values: [
+                      {
+                        entityValue: {
+                          properties: {
+                            longString: {
+                              stringValue: longString,
+                              excludeFromIndexes: true,
+                            },
+                            nestedLongStringArray: {
+                              arrayValue: {
+                                values: [
+                                  {
+                                    entityValue: {
+                                      properties: {
+                                        longString: {
+                                          stringValue: longString,
+                                          excludeFromIndexes: true,
+                                        },
+                                        nestedProperty: {
+                                          booleanValue: true,
+                                        },
+                                      },
+                                    },
+                                  },
+                                  {
+                                    entityValue: {
+                                      properties: {
+                                        longString: {
+                                          stringValue: longString,
+                                          excludeFromIndexes: true,
+                                        },
+                                      },
+                                    },
+                                  },
+                                ],
+                              },
+                            },
+                          },
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          },
+          longStringArray: {
+            arrayValue: {
+              values: [
+                {
+                  entityValue: {
+                    properties: {
+                      longString: {
+                        stringValue: longString,
+                        excludeFromIndexes: true,
+                      },
+                      nestedLongStringArray: {
+                        arrayValue: {
+                          values: [
+                            {
+                              entityValue: {
+                                properties: {
+                                  longString: {
+                                    stringValue: longString,
+                                    excludeFromIndexes: true,
+                                  },
+                                  nestedProperty: {
+                                    booleanValue: true,
+                                  },
+                                },
+                              },
+                            },
+                            {
+                              entityValue: {
+                                properties: {
+                                  longString: {
+                                    stringValue: longString,
+                                    excludeFromIndexes: true,
+                                  },
+                                },
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+  };
+  // complexCaseEntities are passed into save for the complex case.
+  const complexCaseEntities = {
+    longString,
+    notMetadata: true,
+    longStringArray: [longString],
+    metadata: {
+      longString,
+      otherProperty: 'value',
+      obj: {
+        longStringArray: [
+          {
+            longString,
+            nestedLongStringArray: [
+              {
+                longString,
+                nestedProperty: true,
+              },
+              {
+                longString,
+              },
+            ],
+          },
+        ],
+      },
+      longStringArray: [
+        {
+          longString,
+          nestedLongStringArray: [
+            {
+              longString,
+              nestedProperty: true,
+            },
+            {
+              longString,
+            },
+          ],
+        },
+      ],
+    },
+  };
+
+  describe('save should pass the right properties to the gapic layer', () => {
+    async.each(
+      [
+        {
+          name: 'should pass the right properties for a simple name/value pair',
+          skipped: false,
+          entities: {
+            name: 'entityName',
+            value: 'entityValue',
+          },
+          excludeFromIndexes: [], // Empty because excludeLargeProperties populates the list.
+          excludeLargeProperties: true,
+          expectedMutations: [
+            {
+              upsert: {
+                properties: {
+                  name: {
+                    stringValue: 'entityName',
+                  },
+                  value: {
+                    stringValue: 'entityValue',
+                  },
+                },
+                key,
+              },
+            },
+          ],
+        },
+        {
+          // This test checks to see that when the name/value is wrapped in an array it parses the input differently.
+          name: 'should pass the right properties for a simple name/value pair in an array',
+          skipped: false,
+          entities: [
+            {
+              name: 'entityName',
+              value: 'entityValue',
+            },
+          ],
+          excludeFromIndexes: [], // Empty because excludeLargeProperties populates the list.
+          excludeLargeProperties: true,
+          expectedMutations: [
+            {
+              upsert: {
+                properties: {
+                  entityName: {
+                    stringValue: 'entityValue',
+                  },
+                },
+                key,
+              },
+            },
+          ],
+        },
+        {
+          name: 'should position excludeFromIndexes in the right place when provided at the top level',
+          skipped: false,
+          entities: [
+            {
+              name: 'entityName',
+              value: 'entityValue',
+              excludeFromIndexes: true,
+            },
+          ],
+          excludeFromIndexes: [],
+          expectedMutations: [
+            {
+              upsert: {
+                properties: {
+                  entityName: {
+                    stringValue: 'entityValue',
+                    excludeFromIndexes: true,
+                  },
+                },
+                key,
+              },
+            },
+          ],
+        },
+        {
+          name: 'should pass the right properties for a simple name/value pair in an array with excludeFromIndexes list',
+          skipped: true,
+          entities: [
+            {
+              name: 'entityName',
+              value: 'entityValue',
+            },
+          ],
+          excludeFromIndexes: ['entityName'],
+          expectedMutations: [
+            {
+              upsert: {
+                properties: {
+                  entityName: {
+                    stringValue: 'entityValue',
+                    excludeFromIndexes: true,
+                  },
+                },
+                key,
+              },
+            },
+          ],
+        },
+        {
+          // This test is from a modified version of https://github.com/googleapis/nodejs-datastore/blob/bf3dafd8267c447a52f7764505042a60b1a9fd28/test/index.ts#L1773
+          name: 'should pass the right request with a bunch of large properties excluded',
+          skipped: false,
+          entities: complexCaseEntities,
+          excludeFromIndexes: [
+            'longString',
+            'longStringArray[]',
+            'metadata.longString',
+            'metadata.obj.longStringArray[].longString',
+            'metadata.obj.longStringArray[].nestedLongStringArray[].longString',
+            'metadata.longStringArray[].longString',
+            'metadata.longStringArray[].nestedLongStringArray[].longString',
+          ],
+          excludeLargeProperties: false,
+          expectedMutations: [
+            {
+              upsert: {
+                properties: complexCaseProperties,
+                key,
+              },
+            },
+          ],
+        },
+        {
+          // Just like 'should pass the right request with a bunch of large properties excluded', but excludeLargeProperties is true
+          name: 'should pass the right properties for an object with excludeLargeProperties',
+          skipped: false,
+          entities: complexCaseEntities,
+          excludeFromIndexes: [], // Empty because excludeLargeProperties populates the list.
+          excludeLargeProperties: true,
+          expectedMutations: [
+            {
+              upsert: {
+                properties: complexCaseProperties,
+                key,
+              },
+            },
+          ],
+        },
+        {
+          // This test case reproduces https://github.com/googleapis/nodejs-datastore/issues/1242
+          name: 'should pass the right request with a nested field',
+          skipped: true,
+          entities: [
+            {
+              name: 'field_b',
+              value: {
+                nestedField: Buffer.alloc(1501, '.').toString(),
+              },
+              excludeFromIndexes: true,
+            },
+          ],
+          excludeFromIndexes: [],
+          excludeLargeProperties: true,
+          expectedMutations: [
+            {
+              upsert: {
+                properties: {
+                  field_b: {
+                    entityValue: {
+                      properties: {
+                        nestedField: {
+                          stringValue: longString,
+                          excludeFromIndexes: true,
+                        },
+                      },
+                    },
+                    excludeFromIndexes: true,
+                  },
+                },
+                key,
+              },
+            },
+          ],
+        },
+        {
+          // "should pass the right request with a bunch of large properties excluded" test with entities wrapped in name/value
+          name: 'should pass the right request with a name/value pair and a bunch of large properties excluded',
+          skipped: false,
+          entities: {
+            name: 'entityName',
+            value: complexCaseEntities,
+          },
+          excludeFromIndexes: [
+            'value.longString',
+            'value.longStringArray[]',
+            'value.metadata.longString',
+            'value.metadata.obj.longStringArray[].longString',
+            'value.metadata.obj.longStringArray[].nestedLongStringArray[].longString',
+            'value.metadata.longStringArray[].longString',
+            'value.metadata.longStringArray[].nestedLongStringArray[].longString',
+          ],
+          excludeLargeProperties: false,
+          expectedMutations: [
+            {
+              upsert: {
+                properties: {
+                  name: {
+                    stringValue: 'entityName',
+                  },
+                  value: {
+                    entityValue: {
+                      properties: complexCaseProperties,
+                    },
+                  },
+                },
+                key,
+              },
+            },
+          ],
+        },
+        {
+          // "should pass the right properties for an object with excludeLargeProperties" test with entities wrapped in name/value
+          name: 'should pass the right request with a name/value pair and excludeLargeProperties set to true',
+          skipped: false,
+          entities: {
+            name: 'entityName',
+            value: complexCaseEntities,
+          },
+          excludeFromIndexes: [],
+          excludeLargeProperties: true,
+          expectedMutations: [
+            {
+              upsert: {
+                properties: {
+                  name: {
+                    stringValue: 'entityName',
+                  },
+                  value: {
+                    entityValue: {
+                      properties: complexCaseProperties,
+                    },
+                  },
+                },
+                key,
+              },
+            },
+          ],
+        },
+        {
+          // Just like the previous test, but entities are wrapped in an array
+          name: 'should pass the right properties for an array with name/value pairs and excludeLargeProperties',
+          skipped: true,
+          entities: [
+            {
+              name: 'entityName',
+              value: complexCaseEntities,
+            },
+          ],
+          excludeFromIndexes: [],
+          excludeLargeProperties: true,
+          expectedMutations: [
+            {
+              upsert: {
+                properties: {
+                  entityName: {
+                    entityValue: {
+                      properties: complexCaseProperties,
+                    },
+                  },
+                },
+                key,
+              },
+            },
+          ],
+        },
+      ],
+      (test: {
+        name: string;
+        skipped: boolean;
+        entities: Entities;
+        excludeFromIndexes: string[];
+        excludeLargeProperties: boolean;
+        expectedMutations: google.datastore.v1.IMutation[];
+      }) => {
+        it(test.name, async function () {
+          if (test.skipped) {
+            this.skip();
+          }
+          /**
+           * Replaces long strings in an object with <longString> so that they can
+           * be used in an assert comparison as assert has a character limit on the
+           * data that it can accept
+           *
+           * @param {google.datastore.v1.IMutation[] | null} input The input object
+           * containing the long strings that should be replaced.
+           * @returns {google.datastore.v1.IMutation[]} The input object with the long
+           * strings replaced.
+           */
+          function replaceLongStrings(
+            input?: google.datastore.v1.IMutation[] | null
+          ) {
+            const stringifiedInput = JSON.stringify(input);
+            const replacedInput = stringifiedInput
+              .split(longString)
+              .join('<longString>');
+            return JSON.parse(replacedInput) as google.datastore.v1.IMutation[];
+          }
+          {
+            // This code block is indented so the reader knows the rest of the test doesn't depend its definitions.
+            /*
+            Sets up the gapic client so that when it receives mutations it ensures that
+            the mutations match the expectedMutations and throw an assertion error if
+            they don't.
+            */
+            const dataClient = datastore.clients_.get(clientName);
+            if (dataClient) {
+              dataClient.commit = (
+                request: protos.google.datastore.v1.ICommitRequest,
+                options: CallOptions,
+                callback: (
+                  err?: unknown,
+                  res?: protos.google.datastore.v1.ICommitResponse
+                ) => void
+              ) => {
+                try {
+                  const actual = replaceLongStrings(request.mutations);
+                  const expected = replaceLongStrings(test.expectedMutations);
+                  assert.deepStrictEqual(actual, expected);
+                } catch (e) {
+                  callback(e);
+                }
+                callback(null, {
+                  mutationResults: [],
+                });
+              };
+            }
+          }
+          // Calls save and ensures that the right mutations are passed to the Gapic layer.
+          const postKey = datastore.key(['Post', 'post2']);
+          await datastore.save({
+            key: postKey,
+            data: test.entities,
+            excludeFromIndexes: test.excludeFromIndexes,
+            excludeLargeProperties: test.excludeLargeProperties,
+          });
+        });
+      }
+    );
+  });
+});

--- a/test/index.ts
+++ b/test/index.ts
@@ -89,6 +89,7 @@ const fakeEntityInit: any = {
   keyToKeyProto: entity.keyToKeyProto,
   encodeValue: entity.encodeValue,
   entityToEntityProto: entity.entityToEntityProto,
+  addExcludeFromIndexes: entity.addExcludeFromIndexes,
   findLargeProperties_: entity.findLargeProperties_,
   URLSafeKey: entity.URLSafeKey,
 };

--- a/test/index.ts
+++ b/test/index.ts
@@ -1589,7 +1589,7 @@ async.each(
           } catch (err: unknown) {
             assert(
               [
-                `Cannot read properties of null (reading 'toString')`, // Later Node versions
+                "Cannot read properties of null (reading 'toString')", // Later Node versions
                 "Cannot read property 'toString' of null", // Node 14
               ].includes((err as {message: string}).message)
             );

--- a/test/index.ts
+++ b/test/index.ts
@@ -34,6 +34,7 @@ import * as is from 'is';
 import * as sinon from 'sinon';
 import * as extend from 'extend';
 import {google} from '../protos/protos';
+import {ServiceError} from 'google-gax';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const v1 = require('../src/v1/index.js');
@@ -1533,6 +1534,68 @@ async.each(
             gaxOptions,
             assert.ifError
           );
+        });
+
+        it('should throw error when value is not provided', done => {
+          datastore.request_ = (config: RequestConfig) => {
+            done('Should not reach request_ function');
+          };
+
+          try {
+            datastore.save(
+              {
+                key,
+                data: [
+                  {
+                    name: 'something',
+                  },
+                ],
+              },
+              () => {
+                done('Should not reach callback');
+              }
+            );
+          } catch (err: unknown) {
+            assert.strictEqual(
+              (err as {message: string}).message,
+              'Unsupported field value, undefined, was provided.'
+            );
+            done();
+            return;
+          }
+          assert.fail('Calling save should have thrown an error');
+        });
+
+        it('should throw error when name property does not support toString method', done => {
+          datastore.request_ = (config: RequestConfig) => {
+            done('Should not reach request_ function');
+          };
+          try {
+            datastore.save(
+              {
+                key,
+                data: [
+                  {
+                    name: null,
+                    value: 7,
+                  },
+                ],
+              },
+              () => {
+                done('Should not reach callback');
+              }
+            );
+          } catch (err: unknown) {
+            assert(
+              [
+                `Cannot read properties of null (reading 'toString')`, // Later Node versions
+                "Cannot read property 'toString' of null", // Node 14
+              ].includes((err as {message: string}).message)
+            );
+            done();
+            return;
+          }
+          assert.fail('Calling save should have thrown an error');
         });
 
         it('should prepare entity objects', done => {


### PR DESCRIPTION
Solves https://github.com/googleapis/nodejs-datastore/issues/1242.

This PR combines the following PRs which have already been reviewed:

https://github.com/googleapis/nodejs-datastore/pull/1265
https://github.com/googleapis/nodejs-datastore/pull/1264
https://github.com/googleapis/nodejs-datastore/pull/1263
