### PR TITLE
docs: Change description of DatastoreRequest class

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -196,8 +196,7 @@ export enum TransactionState {
 }
 
 /**
- * Handle logic for Datastore API operations. Handles request logic for
- * Datastore.
+ * Handles request logic for Datastore API operations.
  *
  * Creates requests to the Datastore endpoint. Designed to be inherited by
  * the {@link Datastore} and {@link Transaction} classes.


### PR DESCRIPTION
The current description of `DatastoreRequest` makes inconsistent use of plural and singular nouns and is two sentences when it could be one sentence.
