### PR TITLE
docs: Add descriptions to many parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,4 +188,4 @@ See [LICENSE](https://github.com/googleapis/nodejs-datastore/blob/main/LICENSE)
 [projects]: https://console.cloud.google.com/project
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=datastore.googleapis.com
-[auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[auth]: https://cloud.google.com/docs/authentication/provide-credentials-adc#local-dev

--- a/README.md
+++ b/README.md
@@ -188,4 +188,4 @@ See [LICENSE](https://github.com/googleapis/nodejs-datastore/blob/main/LICENSE)
 [projects]: https://console.cloud.google.com/project
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=datastore.googleapis.com
-[auth]: https://cloud.google.com/docs/authentication/provide-credentials-adc#local-dev
+[auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local

--- a/src/aggregate.ts
+++ b/src/aggregate.ts
@@ -43,7 +43,8 @@ class AggregateQuery {
   /**
    * Add a `count` aggregate query to the list of aggregations.
    *
-   * @param {string} alias
+   * @param {string} alias The label used in the results to describe this
+   * aggregate field when a query is run.
    * @returns {AggregateQuery}
    */
   count(alias?: string): AggregateQuery {
@@ -55,7 +56,8 @@ class AggregateQuery {
    * Add a `sum` aggregate query to the list of aggregations.
    *
    * @param {string} property
-   * @param {string} alias
+   * @param {string} alias The label used in the results to describe this
+   * aggregate field when a query is run.
    * @returns {AggregateQuery}
    */
   sum(property: string, alias?: string): AggregateQuery {
@@ -67,7 +69,8 @@ class AggregateQuery {
    * Add a `average` aggregate query to the list of aggregations.
    *
    * @param {string} property
-   * @param {string} alias
+   * @param {string} alias The label used in the results to describe this
+   * aggregate field when a query is run.
    * @returns {AggregateQuery}
    */
   average(property: string, alias?: string): AggregateQuery {

--- a/src/aggregate.ts
+++ b/src/aggregate.ts
@@ -81,7 +81,8 @@ class AggregateQuery {
   /**
    * Add a custom aggregation to the list of aggregations.
    *
-   * @param {AggregateField} aggregation
+   * @param {AggregateField} aggregation The aggregate field to perform the
+   * aggregation query over.
    * @returns {AggregateQuery}
    */
   addAggregation(aggregation: AggregateField): AggregateQuery {
@@ -92,7 +93,8 @@ class AggregateQuery {
   /**
    * Add a list of custom aggregations to the list of aggregations.
    *
-   * @param {AggregateField[]} aggregation
+   * @param {AggregateField[]} aggregations The aggregate fields to perform the
+   * aggregation query over.
    * @returns {AggregateQuery}
    */
   addAggregations(aggregations: AggregateField[]): AggregateQuery {

--- a/src/aggregate.ts
+++ b/src/aggregate.ts
@@ -33,7 +33,7 @@ class AggregateQuery {
   /**
    * Build an AggregateQuery object.
    *
-   * @param {Query} query
+   * @param {Query} query A Query object
    */
   constructor(query: Query) {
     this.query = query;

--- a/src/aggregate.ts
+++ b/src/aggregate.ts
@@ -55,7 +55,7 @@ class AggregateQuery {
   /**
    * Add a `sum` aggregate query to the list of aggregations.
    *
-   * @param {string} property
+   * @param {string} property The property to use for the sum calculation.
    * @param {string} alias The label used in the results to describe this
    * aggregate field when a query is run.
    * @returns {AggregateQuery}
@@ -68,7 +68,7 @@ class AggregateQuery {
   /**
    * Add a `average` aggregate query to the list of aggregations.
    *
-   * @param {string} property
+   * @param {string} property The property to use for the average calculation.
    * @param {string} alias The label used in the results to describe this
    * aggregate field when a query is run.
    * @returns {AggregateQuery}
@@ -212,7 +212,7 @@ abstract class PropertyAggregateField extends AggregateField {
   /**
    * Build a PropertyAggregateField object.
    *
-   * @param {string} property
+   * @param {string} property The property to aggregate over.
    */
   constructor(public property_: string) {
     super();

--- a/src/aggregate.ts
+++ b/src/aggregate.ts
@@ -152,6 +152,7 @@ abstract class AggregateField {
   /**
    * Gets a copy of the Sum aggregate field.
    *
+   * @param {string} property The property to use for the average calculation.
    * @returns {Sum}
    */
   static sum(property: string): Sum {
@@ -161,6 +162,7 @@ abstract class AggregateField {
   /**
    * Gets a copy of the Average aggregate field.
    *
+   * @param {string} property The property to use for the average calculation.
    * @returns {Average}
    */
   static average(property: string): Average {

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -83,7 +83,7 @@ export namespace entity {
    * Check if something is a Datastore Double object.
    *
    * @private
-   * @param {*} value
+   * @param {*} value The value to check if it is a datastore double.
    * @returns {boolean}
    */
   export function isDsDouble(value?: {}): value is entity.Double {
@@ -94,7 +94,7 @@ export namespace entity {
    * Check if a value is a Datastore Double object converted from JSON.
    *
    * @private
-   * @param {*} value
+   * @param {*} value The value to check if it is datastore double like.
    * @returns {boolean}
    */
   export function isDsDoubleLike(value: unknown) {
@@ -204,7 +204,7 @@ export namespace entity {
    * Check if something is a Datastore Int object.
    *
    * @private
-   * @param {*} value
+   * @param {*} value The value to check if it is a Datastore Int
    * @returns {boolean}
    */
   export function isDsInt(value?: {}): value is entity.Int {
@@ -215,7 +215,7 @@ export namespace entity {
    * Check if a value is a Datastore Int object converted from JSON.
    *
    * @private
-   * @param {*} value
+   * @param {*} value The value to check if it is Datastore IntLike
    * @returns {boolean}
    */
   export function isDsIntLike(value: unknown) {
@@ -273,7 +273,7 @@ export namespace entity {
    * Check if something is a Datastore Geo Point object.
    *
    * @private
-   * @param {*} value
+   * @param {*} value The value to check if it is a Geo point.
    * @returns {boolean}
    */
   export function isDsGeoPoint(value?: {}): value is entity.GeoPoint {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1509,7 +1509,7 @@ class Datastore extends DatastoreRequest {
    * @see {@link Query}
    *
    * @param {string} [namespace] Namespace.
-   * @param {string} kind  The kind to query.
+   * @param {string} kind The kind to query.
    * @returns {Query}
    *
    * @example

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,7 +134,7 @@ const urlSafeKey = new entity.URLSafeKey();
  *
  * <h4>The Datastore Emulator</h4>
  *
- * Make sure you have the <a href="https://cloud.google.com/sdk/downloads">
+ * Make sure you have the <a href="https://cloud.google.com/sdk/docs/install">
  * gcloud SDK installed</a>, then run:
  *
  * <pre>

--- a/src/query.ts
+++ b/src/query.ts
@@ -334,7 +334,7 @@ class Query {
    *
    * Queries that select a subset of properties are called Projection Queries.
    *
-   * @see {@link https://cloud.google.com/datastore/docs/concepts/projectionqueries| Projection Queries}
+   * @see {@link https://cloud.google.com/datastore/docs/samples/datastore-projection-query| Projection Queries}
    *
    * @param {string|string[]} fieldNames Properties to return from the matched
    *     entities.

--- a/src/request.ts
+++ b/src/request.ts
@@ -820,7 +820,7 @@ class DatastoreRequest {
    * that uses the end cursor from the previous query as the starting cursor for
    * the next query. You can pass that object back to this method to see if more
    * results exist.
-   * @param {Query} query Query object.
+   * @param {Query} query A Query object
    * @param {object} [options] Optional configuration.
    * @param {string} [options.consistency] Specify either `strong` or `eventual`.
    *     If not specified, default values are chosen by Datastore for the
@@ -949,7 +949,7 @@ class DatastoreRequest {
    *
    * See {@link Datastore#runQuery} for a list of all available options.
    *
-   * @param {Query} query Query object.
+   * @param {Query} query A Query object
    * @param {object} [options] Optional configuration.
    * @param {object} [options.gaxOptions] Request configuration options, outlined
    *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -755,7 +755,7 @@ class Transaction extends DatastoreRequest {
    * has not been started yet then the transaction is started before the
    * runQuery call is made.
    *
-   * @param {Query} query Query object.
+   * @param {Query} query A Query object
    * @param {object} [options] Optional configuration.
    * @param {function} [callback] The callback function. If omitted, a readable
    *     stream instance is returned.


### PR DESCRIPTION
**Summary:**

In the Google Cloud documentation, for many parameters there is no description in the table for parameters. This PR adds descriptions for many of the table cells under parameters that don't have descriptions and corrects others so that descriptions are consistent.

The following is a good example of the problem. The cell for the parameter only contains a type and not a description.

![image](https://github.com/user-attachments/assets/fb0f30a5-aea3-4f0c-a06c-7ce4529995b3)

The cells under description for parameters should look like this:

![image](https://github.com/user-attachments/assets/b76002e2-1e14-4eda-9825-e03b6d7aad55)

A few broken links are fixed as well. They had to be fixed for the CI check.

**Next steps**

There are many more cells under the `Description` column in the documentation that don't contain a description. These table cells should contain a description so more descriptions need to be added for more parameters.