### PR TITLE
docs: Add parameters to second commit overload

### DIFF
--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -159,6 +159,15 @@ class Transaction extends DatastoreRequest {
    * ```
    */
   commit(gaxOptions?: CallOptions): Promise<CommitResponse>;
+  /**
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this request.
+   *   If the commit fails, we automatically try to rollback the transaction
+   * (see {module:datastore/transaction#rollback}).
+   * @param {object} callback.apiResponse The full API response.
+   */
   commit(callback: CommitCallback): void;
   commit(gaxOptions: CallOptions, callback: CommitCallback): void;
   commit(


### PR DESCRIPTION
**Summary:**

In the Google cloud documentation, for many parameters there is no description in the Description column. In particular, there is never parameter description documentation for overloads of methods. This PR provides documentation for parameters in one overload of the commit function to serve as an example of what changes need to be made for function overloads in the documentation everywhere.

For each overload we should provide documentation for the parameters and return descriptions because the tables are already there, but we shouldn't provide any more information because that will make the GCP documentation webpages too long and just repeat information that is already there.

For instance, below is a screenshot of what the documentation looks like for one of the commit overloads:

![image](https://github.com/user-attachments/assets/ae0ea3dd-4fff-4e63-90be-d1d1d96c9255)

The change is that the tables should be filled in with types and descriptions under the description column.

**Next steps:**

Go through the nodejs-datastore source code and add parameter and return value documentation to all of the method overloads.