### PR TITLE
feat: Clients should support the universe domain option

### DIFF
--- a/protos/protos.d.ts
+++ b/protos/protos.d.ts
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/protos.js
+++ b/protos/protos.js
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/index.ts
+++ b/src/index.ts
@@ -676,6 +676,7 @@ class Datastore extends DatastoreRequest {
       gaxOpts.autoPaginate = options.autoPaginate;
     }
 
+    console.log('request_');
     this.request_(
       {
         client: 'DatastoreAdminClient',

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,7 +131,8 @@ const urlSafeKey = new entity.URLSafeKey();
  * This function retrieves the domain from gax.ClientOptions passed in or via an environment variable.
  * It defaults to 'googleapis.com' if none has been set.
  * @param {string} [prefix] The prefix for the domain.
- * @param {gax.ClientOptions} [opts] The gax client options
+ * @param {string} [suffix] The suffix for the domain.
+ * @param {DatastoreOptions} [opts] The gax client options
  * @returns {string} The universe domain.
  */
 function getDomain(prefix: string, suffix: string, opts?: DatastoreOptions) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -136,7 +136,7 @@ const urlSafeKey = new entity.URLSafeKey();
  * @returns {string} The universe domain.
  */
 function getDomain(prefix: string, suffix: string, opts?: DatastoreOptions) {
-  // From https://github.com/googleapis/nodejs-bigtable/blob/589540475b0b2a055018a1cb6e475800fdd46a37/src/v2/bigtable_client.ts#L120-L128.
+  // From https://github.com/googleapis/nodejs-datastore/blob/5c0ddbca91c41e056443eb0b60449f3cdddd6e69/src/v1/datastore_client.ts#L127-L138
   // This code for universe domain was taken from the Gapic Layer.
   // It is reused here to build the service path.
   const universeDomainEnvVar =

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,8 +129,7 @@ const urlSafeKey = new entity.URLSafeKey();
  * Retrieves the domain to be used for the service path.
  *
  * This function retrieves the domain from DatastoreOptions passed in or via an
- * environment variable. It defaults to 'datastore.googleapis.com' if none has
- * been set.
+ * environment variable.
  * @param {string} [prefix] The prefix for the domain.
  * @param {string} [suffix] The suffix for the domain.
  * @param {DatastoreOptions} [opts] The gax client options

--- a/src/index.ts
+++ b/src/index.ts
@@ -128,8 +128,9 @@ const urlSafeKey = new entity.URLSafeKey();
 /**
  * Retrieves the domain to be used for the service path.
  *
- * This function retrieves the domain from gax.ClientOptions passed in or via an environment variable.
- * It defaults to 'googleapis.com' if none has been set.
+ * This function retrieves the domain from DatastoreOptions passed in or via an
+ * environment variable. It defaults to 'datastore.googleapis.com' if none has
+ * been set.
  * @param {string} [prefix] The prefix for the domain.
  * @param {string} [suffix] The suffix for the domain.
  * @param {DatastoreOptions} [opts] The gax client options

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,6 @@ import arrify = require('arrify');
 import extend = require('extend');
 import {
   GrpcClient,
-  ClientOptions,
   ClientStub,
   ChannelCredentials,
   GoogleAuth,
@@ -40,7 +39,7 @@ import {
 import * as is from 'is';
 import {Transform, pipeline} from 'stream';
 
-import {entity, Entities, Entity, EntityProto, ValueProto} from './entity';
+import {entity, Entities, Entity, ValueProto} from './entity';
 import {AggregateField} from './aggregate';
 import Key = entity.Key;
 export {Entity, Key, AggregateField};

--- a/src/index.ts
+++ b/src/index.ts
@@ -676,7 +676,6 @@ class Datastore extends DatastoreRequest {
       gaxOpts.autoPaginate = options.autoPaginate;
     }
 
-    console.log('request_');
     this.request_(
       {
         client: 'DatastoreAdminClient',

--- a/src/request.ts
+++ b/src/request.ts
@@ -1258,7 +1258,9 @@ class DatastoreRequest {
       }
     }
 
+    console.log('load project from auth');
     datastore.auth.getProjectId((err, projectId) => {
+      console.log('loaded project from auth');
       if (err) {
         callback!(err);
         return;

--- a/src/request.ts
+++ b/src/request.ts
@@ -1258,9 +1258,7 @@ class DatastoreRequest {
       }
     }
 
-    console.log('load project from auth');
     datastore.auth.getProjectId((err, projectId) => {
-      console.log('loaded project from auth');
       if (err) {
         callback!(err);
         return;

--- a/test/gapic-mocks/get-initialized-datastore-client.ts
+++ b/test/gapic-mocks/get-initialized-datastore-client.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Datastore} from '../../src';
+import {Datastore, DatastoreOptions} from '../../src';
 
 /**
  * This function gets a datastore client that has already been initialized
@@ -22,15 +22,18 @@ import {Datastore} from '../../src';
  * evaluate data that reaches the handwritten layer thereby testing the
  * handwritten layer in isolation.
  */
-export function getInitializedDatastoreClient(): Datastore {
+export function getInitializedDatastoreClient(
+  opts?: DatastoreOptions
+): Datastore {
   const clientName = 'DatastoreClient';
+  const adminClientName = 'DatastoreAdminClient';
   const PROJECT_ID = 'project-id';
   const NAMESPACE = 'namespace';
   const options = {
     projectId: PROJECT_ID,
     namespace: NAMESPACE,
   };
-  const datastore = new Datastore(options);
+  const datastore = new Datastore(opts ? opts : options);
   // By default, datastore.clients_ is an empty map.
   // To mock out commit we need the map to contain the Gapic data client.
   // Normally a call to the data client through the datastore object would initialize it.
@@ -39,6 +42,13 @@ export function getInitializedDatastoreClient(): Datastore {
   const gapic = Object.freeze({
     v1: require('../../src/v1'),
   });
-  datastore.clients_.set(clientName, new gapic.v1[clientName](options));
+  datastore.clients_.set(
+    clientName,
+    new gapic.v1[clientName](datastore.options)
+  );
+  datastore.clients_.set(
+    adminClientName,
+    new gapic.v1[adminClientName](datastore.options)
+  );
   return datastore;
 }

--- a/test/request.ts
+++ b/test/request.ts
@@ -1886,7 +1886,8 @@ describe('Request', () => {
   });
 
   describe('requestStream_', () => {
-    let GAX_STREAM: gax.CancellableStream;
+    let GAX_STREAM: gax.CancellableStream =
+      new PassThrough() as unknown as gax.CancellableStream;
     const CONFIG = {};
 
     beforeEach(() => {

--- a/test/service-path.ts
+++ b/test/service-path.ts
@@ -14,11 +14,10 @@
 
 import {describe, it} from 'mocha';
 import * as assert from 'assert';
-import {ServiceError} from 'google-gax';
-import {Datastore} from '../src';
 import {DatastoreClient, DatastoreAdminClient} from '../src/v1';
+import {getInitializedDatastoreClient} from './gapic-mocks/get-initialized-datastore-client';
 
-describe.only('Service Path', () => {
+describe('Service Path', () => {
   it('Setting universe domain should set the service path', async () => {
     // Set the environment variable
     process.env.GOOGLE_CLOUD_UNIVERSE_DOMAIN = 'otherDomain';
@@ -27,51 +26,21 @@ describe.only('Service Path', () => {
     const options = {
       universeDomain,
     };
-    const datastore = new Datastore(options);
-    // Need to mock getProjectId_ since it normally uses auth and auth isn't
-    // available in unit tests.
-    (datastore.auth.getProjectId as any) = (
-      callback: (err?: Error | null, projectId?: string | null) => void
-    ) => {
-      callback(null, 'projectId');
-    };
-    try {
-      // This is necessary to initialize the datastore admin client.
-      await datastore.getIndexes({gaxOptions: {timeout: 1000}});
-    } catch (e) {
-      assert.strictEqual(
-        (e as ServiceError).message,
-        'Total timeout of API google.datastore.admin.v1.DatastoreAdmin exceeded 1000 milliseconds retrying error Error: 14 UNAVAILABLE: Name resolution failed for target dns:datastore.someUniverseDomain:443  before any response was received.'
-      );
-    } finally {
-      assert.strictEqual(
-        (
-          datastore.clients_.get(
-            'DatastoreAdminClient'
-          ) as unknown as DatastoreAdminClient
-        )['_opts'].servicePath,
-        `datastore.${universeDomain}`
-      );
-    }
-    try {
-      // This will fail in unit tests, but is necessary to initialize the
-      // datastore client.
-      await datastore.save([], {timeout: 1000});
-    } catch (e) {
-      assert.strictEqual(
-        (e as ServiceError).message,
-        '14 UNAVAILABLE: Name resolution failed for target dns:datastore.someUniverseDomain:443'
-      );
-    } finally {
-      assert.strictEqual(
-        (
-          datastore.clients_.get(
-            'DatastoreClient'
-          ) as unknown as DatastoreClient
-        )['_opts'].servicePath,
-        `datastore.${universeDomain}`
-      );
-    }
+    const datastore = getInitializedDatastoreClient(options);
+    assert.strictEqual(
+      (
+        datastore.clients_.get(
+          'DatastoreAdminClient'
+        ) as unknown as DatastoreAdminClient
+      )['_opts'].servicePath,
+      `datastore.${universeDomain}`
+    );
+    assert.strictEqual(
+      (datastore.clients_.get('DatastoreClient') as unknown as DatastoreClient)[
+        '_opts'
+      ].servicePath,
+      `datastore.${universeDomain}`
+    );
 
     // Clean up the environment variable after the test
     delete process.env.GOOGLE_CLOUD_UNIVERSE_DOMAIN;
@@ -86,51 +55,21 @@ describe.only('Service Path', () => {
       universeDomain,
       apiEndpoint,
     };
-    const datastore = new Datastore(options);
-    // Need to mock getProjectId_ since it normally uses auth and auth isn't
-    // available in unit tests.
-    (datastore.auth.getProjectId as any) = (
-      callback: (err?: Error | null, projectId?: string | null) => void
-    ) => {
-      callback(null, 'projectId');
-    };
-    try {
-      // This is necessary to initialize the bigtable instance admin client.
-      await datastore.getIndexes({gaxOptions: {timeout: 1000}});
-    } catch (e) {
-      assert.strictEqual(
-        (e as ServiceError).message,
-        'Total timeout of API google.datastore.admin.v1.DatastoreAdmin exceeded 1000 milliseconds retrying error Error: 14 UNAVAILABLE: Name resolution failed for target dns:someApiEndpoint:443  before any response was received.'
-      );
-    } finally {
-      assert.strictEqual(
-        (
-          datastore.clients_.get(
-            'DatastoreAdminClient'
-          ) as unknown as DatastoreAdminClient
-        )['_opts'].servicePath,
-        'someApiEndpoint'
-      );
-    }
-    try {
-      // This will fail in unit tests, but is necessary to initialize the
-      // datastore client.
-      await datastore.save([], {timeout: 1000});
-    } catch (e) {
-      assert.strictEqual(
-        (e as ServiceError).message,
-        '14 UNAVAILABLE: Name resolution failed for target dns:someApiEndpoint:443'
-      );
-    } finally {
-      assert.strictEqual(
-        (
-          datastore.clients_.get(
-            'DatastoreClient'
-          ) as unknown as DatastoreClient
-        )['_opts'].servicePath,
-        'someApiEndpoint'
-      );
-    }
+    const datastore = getInitializedDatastoreClient(options);
+    assert.strictEqual(
+      (
+        datastore.clients_.get(
+          'DatastoreAdminClient'
+        ) as unknown as DatastoreAdminClient
+      )['_opts'].servicePath,
+      'someApiEndpoint'
+    );
+    assert.strictEqual(
+      (datastore.clients_.get('DatastoreClient') as unknown as DatastoreClient)[
+        '_opts'
+      ].servicePath,
+      'someApiEndpoint'
+    );
 
     // Clean up the environment variable after the test
     delete process.env.GOOGLE_CLOUD_UNIVERSE_DOMAIN;
@@ -140,56 +79,22 @@ describe.only('Service Path', () => {
 
     // Set the environment variable
     process.env.GOOGLE_CLOUD_UNIVERSE_DOMAIN = universeDomain;
-    const datastore = new Datastore(); // No options needed, it will pick up the env var
+    const datastore = getInitializedDatastoreClient(); // No options needed, it will pick up the env var
 
-    // Need to mock getProjectId_ since it normally uses auth and auth isn't
-    // available in unit tests.
-    (datastore.auth.getProjectId as any) = (
-      callback: (err?: Error | null, projectId?: string | null) => void
-    ) => {
-      callback(null, 'projectId');
-    };
-    try {
-      // This is necessary to initialize the bigtable instance admin client.
-      console.log('getIndexes');
-      await datastore.getIndexes({gaxOptions: {timeout: 1000}});
-    } catch (e) {
-      assert.strictEqual(
-        (e as ServiceError).message,
-        'Total timeout of API google.datastore.admin.v1.DatastoreAdmin exceeded 1000 milliseconds retrying error Error: 14 UNAVAILABLE: Name resolution failed for target dns:datastore.someUniverseDomain:443  before any response was received.'
-      );
-    } finally {
-      assert.strictEqual(
-        (
-          datastore.clients_.get(
-            'DatastoreAdminClient'
-          ) as unknown as DatastoreAdminClient
-        )['_opts'].servicePath,
-        `datastore.${universeDomain}`
-      );
-    }
-    try {
-      // This will fail in unit tests, but is necessary to initialize the
-      // datastore client.
-      await datastore.save([], {timeout: 1000});
-      console.log('After save');
-    } catch (e) {
-      console.log('CATCHING ERROR');
-      console.log((e as any).message);
-      assert.strictEqual(
-        (e as ServiceError).message,
-        '14 UNAVAILABLE: Name resolution failed for target dns:datastore.someUniverseDomain:443'
-      );
-    } finally {
-      assert.strictEqual(
-        (
-          datastore.clients_.get(
-            'DatastoreClient'
-          ) as unknown as DatastoreClient
-        )['_opts'].servicePath,
-        `datastore.${universeDomain}`
-      );
-    }
+    assert.strictEqual(
+      (
+        datastore.clients_.get(
+          'DatastoreAdminClient'
+        ) as unknown as DatastoreAdminClient
+      )['_opts'].servicePath,
+      `datastore.${universeDomain}`
+    );
+    assert.strictEqual(
+      (datastore.clients_.get('DatastoreClient') as unknown as DatastoreClient)[
+        '_opts'
+      ].servicePath,
+      `datastore.${universeDomain}`
+    );
 
     // Clean up the environment variable after the test
     delete process.env.GOOGLE_CLOUD_UNIVERSE_DOMAIN;

--- a/test/service-path.ts
+++ b/test/service-path.ts
@@ -18,7 +18,7 @@ import {ServiceError} from 'google-gax';
 import {Datastore} from '../src';
 import {DatastoreClient, DatastoreAdminClient} from '../src/v1';
 
-describe.only('Service Path', () => {
+describe('Service Path', () => {
   it('Setting universe domain should set the service path', async () => {
     // Set the environment variable
     process.env.GOOGLE_CLOUD_UNIVERSE_DOMAIN = 'otherDomain';

--- a/test/service-path.ts
+++ b/test/service-path.ts
@@ -172,6 +172,7 @@ describe.only('Service Path', () => {
       // This will fail in unit tests, but is necessary to initialize the
       // datastore client.
       await datastore.save([], {timeout: 1000});
+      console.log('After save');
     } catch (e) {
       console.log('CATCHING ERROR');
       console.log((e as any).message);

--- a/test/service-path.ts
+++ b/test/service-path.ts
@@ -37,7 +37,7 @@ describe('Service Path', () => {
     } catch (e) {
       assert.strictEqual(
         (e as ServiceError).message,
-        'Total timeout of API google.datastore.admin.v1.DatastoreAdmin exceeded 1000 milliseconds before any response was received.'
+        'Total timeout of API google.datastore.admin.v1.DatastoreAdmin exceeded 1000 milliseconds retrying error Error: 14 UNAVAILABLE: Name resolution failed for target dns:datastore.someUniverseDomain:443  before any response was received.'
       );
     } finally {
       assert.strictEqual(
@@ -92,7 +92,7 @@ describe('Service Path', () => {
     } catch (e) {
       assert.strictEqual(
         (e as ServiceError).message,
-        'Total timeout of API google.datastore.admin.v1.DatastoreAdmin exceeded 1000 milliseconds before any response was received.'
+        'Total timeout of API google.datastore.admin.v1.DatastoreAdmin exceeded 1000 milliseconds retrying error Error: 14 UNAVAILABLE: Name resolution failed for target dns:someApiEndpoint:443  before any response was received.'
       );
     } finally {
       assert.strictEqual(
@@ -143,7 +143,7 @@ describe('Service Path', () => {
     } catch (e) {
       assert.strictEqual(
         (e as ServiceError).message,
-        'Total timeout of API google.datastore.admin.v1.DatastoreAdmin exceeded 1000 milliseconds before any response was received.'
+        'Total timeout of API google.datastore.admin.v1.DatastoreAdmin exceeded 1000 milliseconds retrying error Error: 14 UNAVAILABLE: Name resolution failed for target dns:datastore.someUniverseDomain:443  before any response was received.'
       );
     } finally {
       assert.strictEqual(

--- a/test/service-path.ts
+++ b/test/service-path.ts
@@ -173,6 +173,8 @@ describe.only('Service Path', () => {
       // datastore client.
       await datastore.save([], {timeout: 1000});
     } catch (e) {
+      console.log('CATCHING ERROR');
+      console.log((e as any).message);
       assert.strictEqual(
         (e as ServiceError).message,
         '14 UNAVAILABLE: Name resolution failed for target dns:datastore.someUniverseDomain:443'

--- a/test/service-path.ts
+++ b/test/service-path.ts
@@ -18,7 +18,7 @@ import {ServiceError} from 'google-gax';
 import {Datastore} from '../src';
 import {DatastoreClient, DatastoreAdminClient} from '../src/v1';
 
-describe('Service Path', () => {
+describe.only('Service Path', () => {
   it('Setting universe domain should set the service path', async () => {
     // Set the environment variable
     process.env.GOOGLE_CLOUD_UNIVERSE_DOMAIN = 'otherDomain';
@@ -30,7 +30,11 @@ describe('Service Path', () => {
     const datastore = new Datastore(options);
     // Need to mock getProjectId_ since it normally uses auth and auth isn't
     // available in unit tests.
-    datastore.getProjectId = () => new Promise(resolve => resolve('projectId'));
+    (datastore.auth.getProjectId as any) = (
+      callback: (err?: Error | null, projectId?: string | null) => void
+    ) => {
+      callback(null, 'projectId');
+    };
     try {
       // This is necessary to initialize the datastore admin client.
       await datastore.getIndexes({gaxOptions: {timeout: 1000}});
@@ -85,7 +89,11 @@ describe('Service Path', () => {
     const datastore = new Datastore(options);
     // Need to mock getProjectId_ since it normally uses auth and auth isn't
     // available in unit tests.
-    datastore.getProjectId = () => new Promise(resolve => resolve('projectId'));
+    (datastore.auth.getProjectId as any) = (
+      callback: (err?: Error | null, projectId?: string | null) => void
+    ) => {
+      callback(null, 'projectId');
+    };
     try {
       // This is necessary to initialize the bigtable instance admin client.
       await datastore.getIndexes({gaxOptions: {timeout: 1000}});
@@ -136,7 +144,11 @@ describe('Service Path', () => {
 
     // Need to mock getProjectId_ since it normally uses auth and auth isn't
     // available in unit tests.
-    datastore.getProjectId = () => new Promise(resolve => resolve('projectId'));
+    (datastore.auth.getProjectId as any) = (
+      callback: (err?: Error | null, projectId?: string | null) => void
+    ) => {
+      callback(null, 'projectId');
+    };
     try {
       // This is necessary to initialize the bigtable instance admin client.
       await datastore.getIndexes({gaxOptions: {timeout: 1000}});

--- a/test/service-path.ts
+++ b/test/service-path.ts
@@ -1,0 +1,181 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {describe, it} from 'mocha';
+import * as assert from 'assert';
+import {ServiceError} from 'google-gax';
+import {Datastore} from '../src';
+import {DatastoreClient, DatastoreAdminClient} from '../src/v1';
+
+describe.only('Service Path', () => {
+  it('Setting universe domain should set the service path', async () => {
+    // Set the environment variable
+    process.env.GOOGLE_CLOUD_UNIVERSE_DOMAIN = 'otherDomain';
+
+    const universeDomain = 'someUniverseDomain'; // or your universe domain if not using emulator
+    const options = {
+      universeDomain,
+    };
+    const datastore = new Datastore(options);
+    // Need to mock getProjectId_ since it normally uses auth and auth isn't
+    // available in unit tests.
+    datastore.getProjectId = () => new Promise(resolve => resolve('projectId'));
+    try {
+      // This is necessary to initialize the datastore admin client.
+      await datastore.getIndexes({gaxOptions: {timeout: 1000}});
+    } catch (e) {
+      assert.strictEqual(
+        (e as ServiceError).message,
+        'Total timeout of API google.datastore.admin.v1.DatastoreAdmin exceeded 1000 milliseconds before any response was received.'
+      );
+    } finally {
+      assert.strictEqual(
+        (
+          datastore.clients_.get(
+            'DatastoreAdminClient'
+          ) as unknown as DatastoreAdminClient
+        )['_opts'].servicePath,
+        `datastore.${universeDomain}`
+      );
+    }
+    try {
+      // This will fail in unit tests, but is necessary to initialize the
+      // datastore client.
+      await datastore.save([], {timeout: 1000});
+    } catch (e) {
+      assert.strictEqual(
+        (e as ServiceError).message,
+        '14 UNAVAILABLE: Name resolution failed for target dns:datastore.someUniverseDomain:443'
+      );
+    } finally {
+      assert.strictEqual(
+        (
+          datastore.clients_.get(
+            'DatastoreClient'
+          ) as unknown as DatastoreClient
+        )['_opts'].servicePath,
+        `datastore.${universeDomain}`
+      );
+    }
+
+    // Clean up the environment variable after the test
+    delete process.env.GOOGLE_CLOUD_UNIVERSE_DOMAIN;
+  });
+  it('Setting universe domain and custom endpoint should set the service path to custom endpoint', async () => {
+    // Set the environment variable
+    process.env.GOOGLE_CLOUD_UNIVERSE_DOMAIN = 'otherDomain';
+
+    const universeDomain = 'someUniverseDomain'; // or your universe domain if not using emulator
+    const apiEndpoint = 'someApiEndpoint';
+    const options = {
+      universeDomain,
+      apiEndpoint,
+    };
+    const datastore = new Datastore(options);
+    // Need to mock getProjectId_ since it normally uses auth and auth isn't
+    // available in unit tests.
+    datastore.getProjectId = () => new Promise(resolve => resolve('projectId'));
+    try {
+      // This is necessary to initialize the bigtable instance admin client.
+      await datastore.getIndexes({gaxOptions: {timeout: 1000}});
+    } catch (e) {
+      assert.strictEqual(
+        (e as ServiceError).message,
+        'Total timeout of API google.datastore.admin.v1.DatastoreAdmin exceeded 1000 milliseconds before any response was received.'
+      );
+    } finally {
+      assert.strictEqual(
+        (
+          datastore.clients_.get(
+            'DatastoreAdminClient'
+          ) as unknown as DatastoreAdminClient
+        )['_opts'].servicePath,
+        'someApiEndpoint'
+      );
+    }
+    try {
+      // This will fail in unit tests, but is necessary to initialize the
+      // datastore client.
+      await datastore.save([], {timeout: 1000});
+    } catch (e) {
+      assert.strictEqual(
+        (e as ServiceError).message,
+        '14 UNAVAILABLE: Name resolution failed for target dns:someApiEndpoint:443'
+      );
+    } finally {
+      assert.strictEqual(
+        (
+          datastore.clients_.get(
+            'DatastoreClient'
+          ) as unknown as DatastoreClient
+        )['_opts'].servicePath,
+        'someApiEndpoint'
+      );
+    }
+
+    // Clean up the environment variable after the test
+    delete process.env.GOOGLE_CLOUD_UNIVERSE_DOMAIN;
+  });
+  it('Setting GOOGLE_CLOUD_UNIVERSE_DOMAIN should set the service path', async () => {
+    const universeDomain = 'someUniverseDomain'; // or your universe domain if not using emulator
+
+    // Set the environment variable
+    process.env.GOOGLE_CLOUD_UNIVERSE_DOMAIN = universeDomain;
+    const datastore = new Datastore(); // No options needed, it will pick up the env var
+
+    // Need to mock getProjectId_ since it normally uses auth and auth isn't
+    // available in unit tests.
+    datastore.getProjectId = () => new Promise(resolve => resolve('projectId'));
+    try {
+      // This is necessary to initialize the bigtable instance admin client.
+      await datastore.getIndexes({gaxOptions: {timeout: 1000}});
+    } catch (e) {
+      assert.strictEqual(
+        (e as ServiceError).message,
+        'Total timeout of API google.datastore.admin.v1.DatastoreAdmin exceeded 1000 milliseconds before any response was received.'
+      );
+    } finally {
+      assert.strictEqual(
+        (
+          datastore.clients_.get(
+            'DatastoreAdminClient'
+          ) as unknown as DatastoreAdminClient
+        )['_opts'].servicePath,
+        `datastore.${universeDomain}`
+      );
+    }
+    try {
+      // This will fail in unit tests, but is necessary to initialize the
+      // datastore client.
+      await datastore.save([], {timeout: 1000});
+    } catch (e) {
+      assert.strictEqual(
+        (e as ServiceError).message,
+        '14 UNAVAILABLE: Name resolution failed for target dns:datastore.someUniverseDomain:443'
+      );
+    } finally {
+      assert.strictEqual(
+        (
+          datastore.clients_.get(
+            'DatastoreClient'
+          ) as unknown as DatastoreClient
+        )['_opts'].servicePath,
+        `datastore.${universeDomain}`
+      );
+    }
+
+    // Clean up the environment variable after the test
+    delete process.env.GOOGLE_CLOUD_UNIVERSE_DOMAIN;
+  });
+});

--- a/test/service-path.ts
+++ b/test/service-path.ts
@@ -151,6 +151,7 @@ describe.only('Service Path', () => {
     };
     try {
       // This is necessary to initialize the bigtable instance admin client.
+      console.log('getIndexes');
       await datastore.getIndexes({gaxOptions: {timeout: 1000}});
     } catch (e) {
       assert.strictEqual(


### PR DESCRIPTION
**Summary:**

The user should be able to set the universe domain so that outgoing calls work with a different Google Cloud Universe. Right now, if the user specifies a universe domain then it will not get used and the request will just be sent to the default Datastore endpoint.

Analogous changes were made in https://github.com/googleapis/nodejs-bigtable/pull/1563.

**Changes:**

`src/index.ts`: If a custom domain isn't provided and a universe domain is provided then instead of using the default url the client will send requests to a url for the universe domain.

`test/service-path.ts`: Add tests for when user provides a universe domain or uses the universe domain environment variable.

`test/gapic-mocks/get-initialized-datastore-client.ts`: A change to the test infrastructure that allows us to create a more realistic initialized Datastore client with a custom set of Datastore options.

`test/request.ts`: The linter is now complaining about this file so a cast is needed.