### PR TITLE
test: Initialize gax stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "precompile": "gts clean"
   },
   "dependencies": {
-    "@google-cloud/promisify": "^4.0.0",
+    "@google-cloud/promisify": "4.0.0",
     "arrify": "^2.0.1",
     "async-mutex": "^0.5.0",
     "concat-stream": "^2.0.0",

--- a/protos/protos.d.ts
+++ b/protos/protos.d.ts
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/protos.js
+++ b/protos/protos.js
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/request.ts
+++ b/test/request.ts
@@ -1886,7 +1886,7 @@ describe('Request', () => {
   });
 
   describe('requestStream_', () => {
-    let GAX_STREAM: gax.CancellableStream;
+    let GAX_STREAM = {} as gax.CancellableStream;
     const CONFIG = {};
 
     beforeEach(() => {

--- a/test/request.ts
+++ b/test/request.ts
@@ -1886,7 +1886,7 @@ describe('Request', () => {
   });
 
   describe('requestStream_', () => {
-    let GAX_STREAM = {} as gax.CancellableStream;
+    let GAX_STREAM: gax.CancellableStream = {} as gax.CancellableStream;
     const CONFIG = {};
 
     beforeEach(() => {


### PR DESCRIPTION
Dependency upgrades have caused a compiler error. The compiler complains because a variable hasn't been initialized. This fix solves the compiler error.

Also, promisify needs to be downgraded to solve a linting issue. A recent promisify upgrade is causing a linting error.
