### PR TITLE
fix: More error visibility in nodejs-datastore

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "async-mutex": "^0.5.0",
     "concat-stream": "^2.0.0",
     "extend": "^3.0.2",
-    "google-gax": "^5.0.1-rc.0",
+    "google-gax": "^5.0.2-rc.1",
     "is": "^3.3.0",
     "protobufjs": "7.0.0",
     "split-array-stream": "^2.0.0",


### PR DESCRIPTION
Changes in google-gax should be made available in nodejs-datastore so that we can see error stacks and identify root causes for errors going forward.
