### PR TITLE
chore: replace old nodejs teams with cloud-sdk-nodejs-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,4 @@
 
 
 # Unless specified, the jsteam is the default owner for nodejs repositories.
-*     @googleapis/cloud-native-db-dpes @googleapis/api-datastore-sdk @googleapis/jsteam
+*     @googleapis/cloud-native-db-dpes @googleapis/api-datastore-sdk @googleapis/cloud-sdk-nodejs-team


### PR DESCRIPTION
b/479541676